### PR TITLE
Replace sqflite flutter plugin by sqlite3 in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Access the dart drivers for the database system you want directly, they all use 
 
 - Mongo - https://pub.dev/packages/mongo_dart
 - Postgres - https://pub.dev/packages/postgres
-- SQLLite -  https://pub.dev/packages/sqflite (careful about this one its mac only, just for example)
+- SQLLite -  https://pub.dev/packages/sqlite3
 
 You will be fine. I have used them this way and they work just fine.
 


### PR DESCRIPTION
This PR replaces the recommended package for sqlite in the docs :

Previous package ([sqflite](https://pub.dev/packages/sqflite)) : 
- is a Flutter package
- works only on android, iOS or MacOS, which are not classic platforms for hosting http servers

New package ([sqlite3](https://pub.dev/packages/sqlite3)) :
- is a Dart package
- thanks to ffi, works natively on any platform