### PR TITLE
remove custom linter rules and auto-apply fixes

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,10 +5,8 @@ include: package:pedantic/analysis_options.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
-linter:
-  rules:
-    prefer_single_quotes:  false
-    omit_local_variable_types: false
+#linter:
+#  rules:
 
 analyzer:
 #   exclude:

--- a/bin/run.dart
+++ b/bin/run.dart
@@ -1,34 +1,34 @@
-import "dart:io";
+import 'dart:io';
 
-import "package:alfred/alfred.dart";
+import 'package:alfred/alfred.dart';
 
 Future<void> main() async {
   final app = Alfred();
 
-  app.all("/example", (req, res) => "Hello world");
+  app.all('/example', (req, res) => 'Hello world');
 
-  app.get("/html", (req, res) {
+  app.get('/html', (req, res) {
     res.headers.contentType = ContentType.html;
-    return "<html><body><h1>Title!</h1></body></html>";
+    return '<html><body><h1>Title!</h1></body></html>';
   });
 
-  app.get("/image", (req, res) => File("test/files/image.jpg"));
+  app.get('/image', (req, res) => File('test/files/image.jpg'));
 
-  app.get("/image/download", (req, res) {
-    res.setDownload(filename: "model10.jpg");
-    final file = File("test/files/image.jpg");
+  app.get('/image/download', (req, res) {
+    res.setDownload(filename: 'model10.jpg');
+    final file = File('test/files/image.jpg');
     res.headers.contentType = file.contentType;
     return file.openRead();
   }, middleware: [
-    (req, res) => {"test": true}
+    (req, res) => {'test': true}
   ]);
 
-  app.get("/redirect",
-      (req, res) => res.redirect(Uri.parse("https://www.google.com")));
+  app.get('/redirect',
+      (req, res) => res.redirect(Uri.parse('https://www.google.com')));
 
-  app.get("/files", (req, res) => Directory("test/files"));
+  app.get('/files', (req, res) => Directory('test/files'));
 
   final server = await app.listen();
 
-  print("Listening on ${server.port}");
+  print('Listening on ${server.port}');
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -5,19 +5,19 @@ import 'package:alfred/alfred.dart';
 void main() async {
   final app = Alfred();
 
-  app.get("/text", (req, res) => "Text response");
+  app.get('/text', (req, res) => 'Text response');
 
-  app.get("/json", (req, res) => {"json_response": true});
+  app.get('/json', (req, res) => {'json_response': true});
 
-  app.get("/jsonExpressStyle", (req, res) {
-    res.json({"type": "traditional_json_response"});
+  app.get('/jsonExpressStyle', (req, res) {
+    res.json({'type': 'traditional_json_response'});
   });
 
-  app.get("/file", (req, res) => File("test/files/image.jpg"));
+  app.get('/file', (req, res) => File('test/files/image.jpg'));
 
-  app.get("/html", (req, res) {
+  app.get('/html', (req, res) {
     res.headers.contentType = ContentType.html;
-    return "<html><body><h1>Test HTML</h1></body></html>";
+    return '<html><body><h1>Test HTML</h1></body></html>';
   });
 
   await app.listen(6565); //Listening on port 6565

--- a/example/example_body_parsing.dart
+++ b/example/example_body_parsing.dart
@@ -3,7 +3,7 @@ import 'package:alfred/alfred.dart';
 void main() async {
   final app = Alfred();
 
-  app.post("/post-route", (req, res) async {
+  app.post('/post-route', (req, res) async {
     final body = await req.body; //JSON body
     body != null; //true
   });

--- a/example/example_cors.dart
+++ b/example/example_cors.dart
@@ -5,7 +5,7 @@ main() async {
   final app = Alfred();
 
   // Warning: defaults to origin "*"
-  app.all("*", cors(origin: "myorigin.com"));
+  app.all('*', cors(origin: 'myorigin.com'));
 
   await app.listen();
 }

--- a/example/example_custom_type_handler.dart
+++ b/example/example_custom_type_handler.dart
@@ -1,7 +1,7 @@
 import 'package:alfred/alfred.dart';
 
 class Chicken {
-  String get response => "I am a chicken";
+  String get response => 'I am a chicken';
 }
 
 void main() {
@@ -14,7 +14,7 @@ void main() {
 
   /// The app will now return the Chicken.response if you return one from a route
 
-  app.get("/kfc", (req, res) => Chicken()); //I am a chicken;
+  app.get('/kfc', (req, res) => Chicken()); //I am a chicken;
 
   app.listen(); //Listening on 3000
 }

--- a/example/example_error_handling.dart
+++ b/example/example_error_handling.dart
@@ -5,10 +5,10 @@ import 'package:alfred/alfred.dart';
 void main() async {
   final app = Alfred(onInternalError: errorHandler);
   await app.listen();
-  app.get("/throwserror", (req, res) => throw Exception("generic exception"));
+  app.get('/throwserror', (req, res) => throw Exception('generic exception'));
 }
 
 FutureOr errorHandler(req, res) {
   res.statusCode = 500;
-  return {"message": "error not handled"};
+  return {'message': 'error not handled'};
 }

--- a/example/example_file_downloads.dart
+++ b/example/example_file_downloads.dart
@@ -5,9 +5,9 @@ import 'package:alfred/alfred.dart';
 void main() async {
   final app = Alfred();
 
-  app.get("/image/download", (req, res) {
-    res.setDownload(filename: "image.jpg");
-    return File("test/files/image.jpg");
+  app.get('/image/download', (req, res) {
+    res.setDownload(filename: 'image.jpg');
+    return File('test/files/image.jpg');
   });
 
   await app.listen(); //Listening on port 3000

--- a/example/example_html.dart
+++ b/example/example_html.dart
@@ -5,9 +5,9 @@ import 'package:alfred/alfred.dart';
 void main() async {
   final app = Alfred();
 
-  app.get("/html", (req, res) {
+  app.get('/html', (req, res) {
     res.headers.contentType = ContentType.html;
-    return "<html><body><h1>Title!</h1></body></html>";
+    return '<html><body><h1>Title!</h1></body></html>';
   });
 
   await app.listen(); //Listening on port 3000

--- a/example/example_middleware.dart
+++ b/example/example_middleware.dart
@@ -9,9 +9,9 @@ FutureOr exampleMiddlware(HttpRequest req, HttpResponse res) {
 
 void main() async {
   final app = Alfred();
-  app.all("/example/:id/:name", (req, res) {
-    req.params["id"] != null; //true
-    req.params["name"] != null; //true;
+  app.all('/example/:id/:name', (req, res) {
+    req.params['id'] != null; //true
+    req.params['name'] != null; //true;
   }, middleware: [exampleMiddlware]);
 
   await app.listen(); //Listening on port 3000

--- a/example/example_middleware_2.dart
+++ b/example/example_middleware_2.dart
@@ -2,11 +2,11 @@ import 'package:alfred/alfred.dart';
 
 void main() async {
   final app = Alfred();
-  app.all("*", (req, res) {
+  app.all('*', (req, res) {
     // Perform action
   });
 
-  app.get("/otherFunction", (req, res) {
+  app.get('/otherFunction', (req, res) {
     //Action performed next
   });
   await app.listen();

--- a/example/example_middleware_authentication_wildcard.dart
+++ b/example/example_middleware_authentication_wildcard.dart
@@ -11,11 +11,11 @@ FutureOr _authenticationMiddleware(HttpRequest req, HttpResponse res) async {
 void main() async {
   final app = Alfred();
 
-  app.all("/resource*", (req, res) => _authenticationMiddleware);
+  app.all('/resource*', (req, res) => _authenticationMiddleware);
 
-  app.get("/resource", (req, res) {}); //Will not be hit
-  app.post("/resource", (req, res) {}); //Will not be hit
-  app.post("/resource/1", (req, res) {}); //Will not be hit
+  app.get('/resource', (req, res) {}); //Will not be hit
+  app.post('/resource', (req, res) {}); //Will not be hit
+  app.post('/resource/1', (req, res) {}); //Will not be hit
 
   await app.listen();
 }

--- a/example/example_missing_handler.dart
+++ b/example/example_missing_handler.dart
@@ -10,5 +10,5 @@ void main() async {
 
 FutureOr missingHandler(HttpRequest req, HttpResponse res) {
   res.statusCode = 404;
-  return {"message": "not found"};
+  return {'message': 'not found'};
 }

--- a/example/example_params.dart
+++ b/example/example_params.dart
@@ -2,9 +2,9 @@ import 'package:alfred/alfred.dart';
 
 void main() async {
   final app = Alfred();
-  app.all("/example/:id/:name", (req, res) {
-    req.params["id"] != null;
-    req.params["name"] != null;
+  app.all('/example/:id/:name', (req, res) {
+    req.params['id'] != null;
+    req.params['name'] != null;
   });
   await app.listen();
 }

--- a/example/example_quickstart.dart
+++ b/example/example_quickstart.dart
@@ -3,9 +3,9 @@ import 'package:alfred/alfred.dart';
 void main() async {
   final app = Alfred();
 
-  app.get("/example", (req, res) => "Hello world");
+  app.get('/example', (req, res) => 'Hello world');
 
   await app.listen();
 
-  print("Listening on port 3000");
+  print('Listening on port 3000');
 }

--- a/example/example_routing.dart
+++ b/example/example_routing.dart
@@ -2,9 +2,9 @@ import 'package:alfred/alfred.dart';
 
 void main() async {
   final app = Alfred();
-  app.all("/example/:id/:name", (req, res) {
-    req.params["id"] != null;
-    req.params["name"] != null;
+  app.all('/example/:id/:name', (req, res) {
+    req.params['id'] != null;
+    req.params['name'] != null;
   });
   await app.listen();
 }

--- a/example/example_static_files.dart
+++ b/example/example_static_files.dart
@@ -6,7 +6,7 @@ void main() async {
   final app = Alfred();
 
   /// Note the wildcard (*) this is very important!!
-  app.get("/public/*", (req, res) => Directory("test/files"));
+  app.get('/public/*', (req, res) => Directory('test/files'));
 
   await app.listen();
 }

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -150,7 +150,7 @@ class Alfred {
   /// Call this function to fire off the server
   ///
   Future<HttpServer> listen(
-      [int port = 3000, dynamic bindIp = "0.0.0.0"]) async {
+      [int port = 3000, dynamic bindIp = '0.0.0.0']) async {
     final _server = await HttpServer.bind(bindIp, port);
     _server.idleTimeout = Duration(seconds: 1);
 
@@ -164,10 +164,10 @@ class Alfred {
   /// Handles and routes an incoming request
   ///
   Future _incomingRequest(HttpRequest request) async {
-    bool isDone = false;
+    var isDone = false;
 
     if (logRequests) {
-      print("${request.method} - ${request.uri.toString()}");
+      print('${request.method} - ${request.uri.toString()}');
     }
 
     // We track if the response has been resolved in order to exit out early
@@ -198,7 +198,7 @@ class Alfred {
         } else {
           // Otherwise throw a generic 404;
           request.response.statusCode = 404;
-          request.response.write("404 not found");
+          request.response.write('404 not found');
           await request.response.close();
         }
       } else {
@@ -208,7 +208,7 @@ class Alfred {
             break;
           }
           //TODO: This is a hack to match the params of the selected route
-          request.response.headers.set("x-alfred-route", route.route);
+          request.response.headers.set('x-alfred-route', route.route);
 
           /// Loop through any middleware
           for (var middleware in route.middleware) {

--- a/lib/src/extensions/file_helpers.dart
+++ b/lib/src/extensions/file_helpers.dart
@@ -13,7 +13,7 @@ extension FileHelpers on File {
   ContentType? get contentType {
     final mimeType = this.mimeType;
     if (mimeType != null) {
-      final split = mimeType.split("/");
+      final split = mimeType.split('/');
       return ContentType(split[0], split[1]);
     }
   }

--- a/lib/src/extensions/request_helpers.dart
+++ b/lib/src/extensions/request_helpers.dart
@@ -23,5 +23,5 @@ extension RequestHelpers on HttpRequest {
 
   /// Get the matched route of the current request
   ///
-  String get route => response.headers.value("x-alfred-route") ?? "";
+  String get route => response.headers.value('x-alfred-route') ?? '';
 }

--- a/lib/src/extensions/response_helpers.dart
+++ b/lib/src/extensions/response_helpers.dart
@@ -11,7 +11,7 @@ extension ResponseHelpers on HttpResponse {
   /// Set the appropriate headers to download the file
   ///
   void setDownload({required String filename}) {
-    headers.add("Content-Disposition", "attachment; filename=$filename");
+    headers.add('Content-Disposition', 'attachment; filename=$filename');
   }
 
   /// Set the content type from the extension ie. 'pdf'
@@ -19,7 +19,7 @@ extension ResponseHelpers on HttpResponse {
   void setContentTypeFromExtension(String extension) {
     final mime = mimeFromExtension(extension);
     if (mime != null) {
-      final split = mime.split("/");
+      final split = mime.split('/');
       headers.contentType = ContentType(split[0], split[1]);
     }
   }
@@ -28,7 +28,7 @@ extension ResponseHelpers on HttpResponse {
   ///
   void setContentTypeFromFile(File file) {
     if (headers.contentType == null ||
-        headers.contentType!.mimeType == "text/plain") {
+        headers.contentType!.mimeType == 'text/plain') {
       headers.contentType = file.contentType;
     } else {
       headers.contentType == ContentType.binary;

--- a/lib/src/middleware/cors.dart
+++ b/lib/src/middleware/cors.dart
@@ -6,13 +6,13 @@ import 'dart:io';
 /// Has some sensible defaults. You probably want to change the origin
 FutureOr Function(HttpRequest, HttpResponse) cors(
     {int age = 86400,
-    String headers = "Content-Type",
-    String methods = "POST, GET, OPTIONS, PUT, PATCH",
-    String origin = "*"}) {
+    String headers = 'Content-Type',
+    String methods = 'POST, GET, OPTIONS, PUT, PATCH',
+    String origin = '*'}) {
   return (HttpRequest req, HttpResponse res) {
-    res.headers.set("Access-Control-Allow-Origin", origin);
-    res.headers.set("Access-Control-Allow-Methods", methods);
-    res.headers.set("Access-Control-Allow-Headers", headers);
-    res.headers.set("Access-Control-Max-Age", age);
+    res.headers.set('Access-Control-Allow-Origin', origin);
+    res.headers.set('Access-Control-Allow-Methods', methods);
+    res.headers.set('Access-Control-Allow-Headers', headers);
+    res.headers.set('Access-Control-Max-Age', age);
   };
 }

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -7,27 +7,27 @@ class RouteMatcher {
       String input, List<HttpRoute> options, Method method) {
     final inputParts = List<String>.from(Uri.parse(input).pathSegments);
 
-    if (inputParts.isNotEmpty && inputParts.last == "") {
+    if (inputParts.isNotEmpty && inputParts.last == '') {
       inputParts.removeLast();
     }
 
     var output = <HttpRoute>[];
 
     for (var item in options) {
-      bool mustWildcard = false;
+      var mustWildcard = false;
 
       if (item.method != method && item.method != Method.all) {
         continue;
       }
 
-      if (item.route == "*") {
+      if (item.route == '*') {
         output.add(item);
         continue;
       }
 
       final itemParts = List<String>.from(Uri.parse(item.route).pathSegments);
 
-      if (itemParts.isNotEmpty && itemParts.last == "") {
+      if (itemParts.isNotEmpty && itemParts.last == '') {
         itemParts.removeLast();
       }
 
@@ -40,20 +40,20 @@ class RouteMatcher {
       }
 
       var matchesAll = true;
-      bool didWildcard = false;
+      var didWildcard = false;
       for (var i = 0; i < itemParts.length; i++) {
-        if (itemParts[i].startsWith(":")) {
+        if (itemParts[i].startsWith(':')) {
           continue;
         }
-        if (itemParts[i] == "*") {
+        if (itemParts[i] == '*') {
           didWildcard = true;
           break;
         }
-        if (itemParts[i].endsWith("*")) {
+        if (itemParts[i].endsWith('*')) {
           didWildcard = true;
           break;
         }
-        if (!RegExp("^${itemParts[i]}\$", caseSensitive: false)
+        if (!RegExp('^${itemParts[i]}\$', caseSensitive: false)
             .hasMatch(inputParts[i])) {
           matchesAll = false;
           break;
@@ -68,8 +68,8 @@ class RouteMatcher {
   }
 
   static Map<String, String> getParams(String route, String input) {
-    final routeParts = route.split("/")..remove("");
-    final inputParts = input.split("/")..remove("");
+    final routeParts = route.split('/')..remove('');
+    final inputParts = input.split('/')..remove('');
 
     if (inputParts.length != routeParts.length) {
       throw NotMatchingRouteException();
@@ -81,8 +81,8 @@ class RouteMatcher {
       final routePart = routeParts[i];
       final inputPart = inputParts[i];
 
-      if (routePart.contains(":")) {
-        final routeParams = routePart.split(":")..remove("");
+      if (routePart.contains(':')) {
+        final routeParams = routePart.split(':')..remove('');
 
         for (var item in routeParams) {
           output[item] = inputPart;

--- a/lib/src/type_handlers/binary_type_handlers.dart
+++ b/lib/src/type_handlers/binary_type_handlers.dart
@@ -6,7 +6,7 @@ import 'package:alfred/src/type_handlers/type_handler.dart';
 
 FutureOr _binaryTypeHandler(req, res, val) async {
   if (res.headers.contentType == null ||
-      res.headers.contentType!.value == "text/plain") {
+      res.headers.contentType!.value == 'text/plain') {
     res.headers.contentType = ContentType.binary;
   }
   res.add(val);
@@ -21,7 +21,7 @@ TypeHandler get uint8listTypeHandler =>
 TypeHandler get binaryStreamTypeHandler => TypeHandler<Stream<List<int>>>(
         (HttpRequest req, HttpResponse res, val) async {
       if (res.headers.contentType == null ||
-          res.headers.contentType!.value == "text/plain") {
+          res.headers.contentType!.value == 'text/plain') {
         res.headers.contentType = ContentType.binary;
       }
       await res.addStream(val);

--- a/lib/src/type_handlers/directory_type_handler.dart
+++ b/lib/src/type_handlers/directory_type_handler.dart
@@ -12,7 +12,7 @@ TypeHandler get directoryTypeHandler =>
       final file = File(filePath);
       final exists = await file.exists();
       if (!exists) {
-        throw AlfredException(404, {"message": "file not found"});
+        throw AlfredException(404, {'message': 'file not found'});
       }
       res.setContentTypeFromFile(file);
       await res.addStream(file.openRead());

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -21,114 +21,114 @@ void main() {
     await app.close();
   });
 
-  test("it should return a string correctly", () async {
-    app.get("/test", (req, res) => "test string");
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.body, "test string");
+  test('it should return a string correctly', () async {
+    app.get('/test', (req, res) => 'test string');
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'test string');
   });
 
-  test("it should return json", () async {
-    app.get("/test", (req, res) => {"test": true});
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.headers["content-type"], "application/json; charset=utf-8");
+  test('it should return json', () async {
+    app.get('/test', (req, res) => {'test': true});
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.headers['content-type'], 'application/json; charset=utf-8');
     expect(response.body, '{"test":true}');
   });
 
-  test("it should return an image", () async {
-    app.get("/test", (req, res) => File("test/files/image.jpg"));
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.headers["content-type"], "image/jpeg");
+  test('it should return an image', () async {
+    app.get('/test', (req, res) => File('test/files/image.jpg'));
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.headers['content-type'], 'image/jpeg');
   });
 
-  test("it should return a pdf", () async {
-    app.get("/test", (req, res) => File("test/files/dummy.pdf"));
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.headers["content-type"], "application/pdf");
+  test('it should return a pdf', () async {
+    app.get('/test', (req, res) => File('test/files/dummy.pdf'));
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.headers['content-type'], 'application/pdf');
   });
 
-  test("routing should, you know, work", () async {
-    app.get("/test", (req, res) => "test_route");
-    app.get("/testRoute", (req, res) => "test_route_route");
-    app.get("/a", (req, res) => "a_route");
-    expect((await http.get(Uri.parse("http://localhost:$port/test"))).body,
-        "test_route");
-    expect((await http.get(Uri.parse("http://localhost:$port/testRoute"))).body,
-        "test_route_route");
-    expect((await http.get(Uri.parse("http://localhost:$port/a"))).body,
-        "a_route");
+  test('routing should, you know, work', () async {
+    app.get('/test', (req, res) => 'test_route');
+    app.get('/testRoute', (req, res) => 'test_route_route');
+    app.get('/a', (req, res) => 'a_route');
+    expect((await http.get(Uri.parse('http://localhost:$port/test'))).body,
+        'test_route');
+    expect((await http.get(Uri.parse('http://localhost:$port/testRoute'))).body,
+        'test_route_route');
+    expect((await http.get(Uri.parse('http://localhost:$port/a'))).body,
+        'a_route');
   });
 
-  test("error handling", () async {
+  test('error handling', () async {
     await app.close();
     app = Alfred(onInternalError: (req, res) {
       res.statusCode = 500;
-      return {"message": "error not handled"};
+      return {'message': 'error not handled'};
     });
     await app.listen(port);
-    app.get("/throwserror", (req, res) => throw Exception("generic exception"));
+    app.get('/throwserror', (req, res) => throw Exception('generic exception'));
 
     expect(
-        (await http.get(Uri.parse("http://localhost:$port/throwserror"))).body,
+        (await http.get(Uri.parse('http://localhost:$port/throwserror'))).body,
         '{"message":"error not handled"}');
   });
 
-  test("error default handling", () async {
+  test('error default handling', () async {
     await app.close();
     app = Alfred();
     await app.listen(port);
-    app.get("/throwserror", (req, res) => throw Exception("generic exception"));
+    app.get('/throwserror', (req, res) => throw Exception('generic exception'));
 
     final response =
-        await http.get(Uri.parse("http://localhost:$port/throwserror"));
+        await http.get(Uri.parse('http://localhost:$port/throwserror'));
     expect(response.body, 'Exception: generic exception');
   });
 
-  test("not found handling", () async {
+  test('not found handling', () async {
     await app.close();
     app = Alfred(onNotFound: (req, res) {
       res.statusCode = 404;
-      return {"message": "not found"};
+      return {'message': 'not found'};
     });
     await app.listen(port);
 
     final response =
-        (await http.get(Uri.parse("http://localhost:$port/notfound")));
+        (await http.get(Uri.parse('http://localhost:$port/notfound')));
     expect(response.body, '{"message":"not found"}');
     expect(response.statusCode, 404);
   });
 
-  test("not found default handling", () async {
+  test('not found default handling', () async {
     await app.close();
     app = Alfred();
     await app.listen(port);
 
     final response =
-        (await http.get(Uri.parse("http://localhost:$port/notfound")));
+        (await http.get(Uri.parse('http://localhost:$port/notfound')));
     expect(response.body, '404 not found');
     expect(response.statusCode, 404);
   });
 
-  test("it handles a post request", () async {
-    app.post("/test", (req, res) => "test string");
-    final response = await http.post(Uri.parse("http://localhost:$port/test"));
-    expect(response.body, "test string");
+  test('it handles a post request', () async {
+    app.post('/test', (req, res) => 'test string');
+    final response = await http.post(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'test string');
   });
 
-  test("it handles a put request", () async {
-    app.put("/test", (req, res) => "test string");
-    final response = await http.put(Uri.parse("http://localhost:$port/test"));
-    expect(response.body, "test string");
+  test('it handles a put request', () async {
+    app.put('/test', (req, res) => 'test string');
+    final response = await http.put(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'test string');
   });
 
-  test("it handles a delete request", () async {
-    app.delete("/test", (req, res) => "test string");
+  test('it handles a delete request', () async {
+    app.delete('/test', (req, res) => 'test string');
     final response =
-        await http.delete(Uri.parse("http://localhost:$port/test"));
-    expect(response.body, "test string");
+        await http.delete(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'test string');
   });
 
-  test("it handles an options request", () async {
-    app.options("/test", (req, res) => "test string");
+  test('it handles an options request', () async {
+    app.options('/test', (req, res) => 'test string');
 
     /// TODO: Need to find a way to send an options request. The HTTP library doesn't
     /// seem to support it.
@@ -137,169 +137,169 @@ void main() {
     // expect(response.body, "test string");
   });
 
-  test("it handles a patch request", () async {
-    app.patch("/test", (req, res) => "test string");
-    final response = await http.patch(Uri.parse("http://localhost:$port/test"));
-    expect(response.body, "test string");
+  test('it handles a patch request', () async {
+    app.patch('/test', (req, res) => 'test string');
+    final response = await http.patch(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'test string');
   });
 
-  test("it handles a route that hits all methods", () async {
-    app.all("/test", (req, res) => "test all");
+  test('it handles a route that hits all methods', () async {
+    app.all('/test', (req, res) => 'test all');
     final responseGet =
-        await http.get(Uri.parse("http://localhost:$port/test"));
+        await http.get(Uri.parse('http://localhost:$port/test'));
     final responsePost =
-        await http.post(Uri.parse("http://localhost:$port/test"));
+        await http.post(Uri.parse('http://localhost:$port/test'));
     final responsePut =
-        await http.put(Uri.parse("http://localhost:$port/test"));
+        await http.put(Uri.parse('http://localhost:$port/test'));
     final responseDelete =
-        await http.delete(Uri.parse("http://localhost:$port/test"));
-    expect(responseGet.body, "test all");
-    expect(responsePost.body, "test all");
-    expect(responsePut.body, "test all");
-    expect(responseDelete.body, "test all");
+        await http.delete(Uri.parse('http://localhost:$port/test'));
+    expect(responseGet.body, 'test all');
+    expect(responsePost.body, 'test all');
+    expect(responsePut.body, 'test all');
+    expect(responseDelete.body, 'test all');
   });
 
-  test("it executes middleware, but passes through", () async {
-    bool hitMiddleware = false;
-    app.get("/test", (req, res) => "test route", middleware: [
+  test('it executes middleware, but passes through', () async {
+    var hitMiddleware = false;
+    app.get('/test', (req, res) => 'test route', middleware: [
       (req, res) {
         hitMiddleware = true;
       }
     ]);
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.body, "test route");
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'test route');
     expect(hitMiddleware, true);
   });
 
-  test("it executes middleware, but handles it and stops executing", () async {
-    app.get("/test", (req, res) => "test route", middleware: [
+  test('it executes middleware, but handles it and stops executing', () async {
+    app.get('/test', (req, res) => 'test route', middleware: [
       (req, res) {
-        return "hit middleware";
+        return 'hit middleware';
       }
     ]);
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.body, "hit middleware");
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'hit middleware');
   });
 
-  test("it closes out a request if you fail to", () async {
-    app.get("/test", (req, res) => null);
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
+  test('it closes out a request if you fail to', () async {
+    app.get('/test', (req, res) => null);
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.body, '');
   });
 
-  test("it throws and handles an exception", () async {
-    app.get("/test", (req, res) => throw AlfredException(360, "exception"));
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
+  test('it throws and handles an exception', () async {
+    app.get('/test', (req, res) => throw AlfredException(360, 'exception'));
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.body, 'exception');
     expect(response.statusCode, 360);
   });
 
-  test("it handles a List<int>", () async {
-    app.get("/test", (req, res) => <int>[1, 2, 3, 4, 5]);
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
+  test('it handles a List<int>', () async {
+    app.get('/test', (req, res) => <int>[1, 2, 3, 4, 5]);
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.body, '\x01\x02\x03\x04\x05');
-    expect(response.headers["content-type"], 'application/octet-stream');
+    expect(response.headers['content-type'], 'application/octet-stream');
   });
 
-  test("it handles a Stream<List<int>>", () async {
+  test('it handles a Stream<List<int>>', () async {
     app.get(
-        "/test",
+        '/test',
         (req, res) => Stream.fromIterable([
               [1, 2, 3, 4, 5]
             ]));
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.body, '\x01\x02\x03\x04\x05');
-    expect(response.headers["content-type"], 'application/octet-stream');
+    expect(response.headers['content-type'], 'application/octet-stream');
   });
 
-  test("it parses a body", () async {
-    app.post("/test", (req, res) async {
+  test('it parses a body', () async {
+    app.post('/test', (req, res) async {
       final body = await req.body;
       expect(body is Map, true);
-      expect(req.contentType!.mimeType, "application/json");
-      return "test result";
+      expect(req.contentType!.mimeType, 'application/json');
+      return 'test result';
     });
 
-    final response = await http.post(Uri.parse("http://localhost:$port/test"),
-        headers: {"Content-Type": "application/json"},
-        body: jsonEncode({"test": true}));
-    expect(response.body, "test result");
+    final response = await http.post(Uri.parse('http://localhost:$port/test'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'test': true}));
+    expect(response.body, 'test result');
   });
 
-  test("it serves a file for download", () async {
-    app.get("/test", (req, res) {
-      res.setDownload(filename: "testfile.jpg");
-      return File("./test/files/image.jpg");
+  test('it serves a file for download', () async {
+    app.get('/test', (req, res) {
+      res.setDownload(filename: 'testfile.jpg');
+      return File('./test/files/image.jpg');
     });
 
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.headers["content-type"], 'image/jpeg');
-    expect(response.headers["content-disposition"],
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.headers['content-type'], 'image/jpeg');
+    expect(response.headers['content-disposition'],
         'attachment; filename=testfile.jpg');
   });
 
-  test("it serves a pdf, setting the extension from the filename", () async {
-    app.get("/test", (req, res) {
-      res.setContentTypeFromExtension("pdf");
-      return File("./test/files/dummy.pdf");
+  test('it serves a pdf, setting the extension from the filename', () async {
+    app.get('/test', (req, res) {
+      res.setContentTypeFromExtension('pdf');
+      return File('./test/files/dummy.pdf');
     });
 
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.headers["content-type"], 'application/pdf');
-    expect(response.headers["content-disposition"], null);
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.headers['content-type'], 'application/pdf');
+    expect(response.headers['content-disposition'], null);
   });
 
-  test("it uses the json helper correctly", () async {
-    app.get("/test", (req, res) async {
-      await res.json({"success": true});
+  test('it uses the json helper correctly', () async {
+    app.get('/test', (req, res) async {
+      await res.json({'success': true});
     });
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.body, '{"success":true}');
   });
 
-  test("it uses the send helper correctly", () async {
-    app.get("/test", (req, res) async {
-      await res.send("stuff");
+  test('it uses the send helper correctly', () async {
+    app.get('/test', (req, res) async {
+      await res.send('stuff');
     });
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.body, 'stuff');
   });
 
-  test("it serves static files", () async {
-    app.get("/files/*", (req, res) => Directory("test/files"));
+  test('it serves static files', () async {
+    app.get('/files/*', (req, res) => Directory('test/files'));
 
     final response =
-        await http.get(Uri.parse("http://localhost:$port/files/dummy.pdf"));
+        await http.get(Uri.parse('http://localhost:$port/files/dummy.pdf'));
     expect(response.statusCode, 200);
-    expect(response.headers["content-type"], "application/pdf");
+    expect(response.headers['content-type'], 'application/pdf');
 
     final responseNotFound = await http
-        .get(Uri.parse("http://localhost:$port/files/doesnotexist.png"));
+        .get(Uri.parse('http://localhost:$port/files/doesnotexist.png'));
     expect(responseNotFound.statusCode, 404);
     expect(responseNotFound.body, '{"message":"file not found"}');
   });
 
-  test("it routes correctly for a / url", () async {
-    app.get("/", (req, res) => "working");
-    final response = await http.get(Uri.parse("http://localhost:$port/"));
+  test('it routes correctly for a / url', () async {
+    app.get('/', (req, res) => 'working');
+    final response = await http.get(Uri.parse('http://localhost:$port/'));
 
-    expect(response.body, "working");
+    expect(response.body, 'working');
   });
 
-  test("it handles params", () async {
-    app.get("/test/:id", (req, res) => req.params["id"]);
+  test('it handles params', () async {
+    app.get('/test/:id', (req, res) => req.params['id']);
     final response =
-        await http.get(Uri.parse("http://localhost:$port/test/15"));
-    expect(response.body, "15");
+        await http.get(Uri.parse('http://localhost:$port/test/15'));
+    expect(response.body, '15');
   });
 
-  test("it should implement cors correctly", () async {
-    app.all("*", cors(origin: "test-origin"));
+  test('it should implement cors correctly', () async {
+    app.all('*', cors(origin: 'test-origin'));
 
-    final response = await http.get(Uri.parse("http://localhost:$port/test"));
-    expect(response.headers.containsKey("access-control-allow-origin"), true);
-    expect(response.headers["access-control-allow-origin"], "test-origin");
-    expect(response.headers.containsKey("access-control-allow-headers"), true);
-    expect(response.headers.containsKey("access-control-allow-methods"), true);
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.headers.containsKey('access-control-allow-origin'), true);
+    expect(response.headers['access-control-allow-origin'], 'test-origin');
+    expect(response.headers.containsKey('access-control-allow-headers'), true);
+    expect(response.headers.containsKey('access-control-allow-methods'), true);
   });
 }

--- a/test/benchmarker.dart
+++ b/test/benchmarker.dart
@@ -4,7 +4,7 @@ void main() async {
   final stopwatch = Stopwatch()..start();
   final actions = <Future>[];
   for (var i = 0; i < 1000; i++) {
-    actions.add(http.get(Uri.parse("http://localhost:12345/files/dummy.pdf")));
+    actions.add(http.get(Uri.parse('http://localhost:12345/files/dummy.pdf')));
   }
   await Future.wait(actions);
   print(stopwatch.elapsed);

--- a/test/route_matcher_test.dart
+++ b/test/route_matcher_test.dart
@@ -3,171 +3,171 @@ import 'package:alfred/src/route_matcher.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("it should match routes correctly", () {
+  test('it should match routes correctly', () {
     final testRoutes = [
-      HttpRoute("/a/:id/go", (req, res) async {}, Method.get),
-      HttpRoute("/a", (req, res) async {}, Method.get),
-      HttpRoute("/b/a/:input/another", (req, res) async {}, Method.get),
-      HttpRoute("/b/a/:input", (req, res) async {}, Method.get),
-      HttpRoute("/b/B/:input", (req, res) async {}, Method.get),
-      HttpRoute("/[a-z]/yep", (req, res) async {}, Method.get),
+      HttpRoute('/a/:id/go', (req, res) async {}, Method.get),
+      HttpRoute('/a', (req, res) async {}, Method.get),
+      HttpRoute('/b/a/:input/another', (req, res) async {}, Method.get),
+      HttpRoute('/b/a/:input', (req, res) async {}, Method.get),
+      HttpRoute('/b/B/:input', (req, res) async {}, Method.get),
+      HttpRoute('/[a-z]/yep', (req, res) async {}, Method.get),
     ];
 
     expect(
-        RouteMatcher.match("/a", testRoutes, Method.get)
+        RouteMatcher.match('/a', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/a"]);
+        ['/a']);
     expect(
-        RouteMatcher.match("/a?query=true", testRoutes, Method.get)
+        RouteMatcher.match('/a?query=true', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/a"]);
+        ['/a']);
     expect(
-        RouteMatcher.match("/a/123/go", testRoutes, Method.get)
+        RouteMatcher.match('/a/123/go', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/a/:id/go"]);
+        ['/a/:id/go']);
     expect(
-        RouteMatcher.match("/a/123/go/a", testRoutes, Method.get)
+        RouteMatcher.match('/a/123/go/a', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
         []);
     expect(
-        RouteMatcher.match("/b/a/adskfjasjklf/another", testRoutes, Method.get)
+        RouteMatcher.match('/b/a/adskfjasjklf/another', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/b/a/:input/another"]);
+        ['/b/a/:input/another']);
     expect(
-        RouteMatcher.match("/b/a/adskfjasj", testRoutes, Method.get)
+        RouteMatcher.match('/b/a/adskfjasj', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/b/a/:input"]);
+        ['/b/a/:input']);
     expect(
-        RouteMatcher.match("/d/yep", testRoutes, Method.get)
+        RouteMatcher.match('/d/yep', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/[a-z]/yep"]);
+        ['/[a-z]/yep']);
     expect(
-        RouteMatcher.match("/b/B/yep", testRoutes, Method.get)
+        RouteMatcher.match('/b/B/yep', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/b/B/:input"]);
+        ['/b/B/:input']);
   });
 
-  test("it should match wildcards", () {
+  test('it should match wildcards', () {
     final testRoutes = [
-      HttpRoute("*", (req, res) async {}, Method.get),
-      HttpRoute("/a", (req, res) async {}, Method.get),
-      HttpRoute("/b", (req, res) async {}, Method.get),
+      HttpRoute('*', (req, res) async {}, Method.get),
+      HttpRoute('/a', (req, res) async {}, Method.get),
+      HttpRoute('/b', (req, res) async {}, Method.get),
     ];
 
     expect(
-        RouteMatcher.match("/a", testRoutes, Method.get)
+        RouteMatcher.match('/a', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["*", "/a"]);
+        ['*', '/a']);
   });
 
-  test("it should respect the routemethod", () {
+  test('it should respect the routemethod', () {
     final testRoutes = [
-      HttpRoute("*", (req, res) async {}, Method.post),
-      HttpRoute("/a", (req, res) async {}, Method.get),
-      HttpRoute("/b", (req, res) async {}, Method.get),
+      HttpRoute('*', (req, res) async {}, Method.post),
+      HttpRoute('/a', (req, res) async {}, Method.get),
+      HttpRoute('/b', (req, res) async {}, Method.get),
     ];
 
     expect(
-        RouteMatcher.match("/a", testRoutes, Method.get)
+        RouteMatcher.match('/a', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/a"]);
+        ['/a']);
   });
 
-  test("it should extract the route params correctly", () {
-    expect(RouteMatcher.getParams("/a/:value/:value2", "/a/input/input2"), {
-      "value": "input",
-      "value2": "input2",
+  test('it should extract the route params correctly', () {
+    expect(RouteMatcher.getParams('/a/:value/:value2', '/a/input/input2'), {
+      'value': 'input',
+      'value2': 'input2',
     });
   });
 
-  test("it should correctly match routes that have a partial match", () {
+  test('it should correctly match routes that have a partial match', () {
     final testRoutes = [
-      HttpRoute("/image", (req, res) async {}, Method.get),
-      HttpRoute("/imageSource", (req, res) async {}, Method.get)
+      HttpRoute('/image', (req, res) async {}, Method.get),
+      HttpRoute('/imageSource', (req, res) async {}, Method.get)
     ];
 
     expect(
-        RouteMatcher.match("/imagesource", testRoutes, Method.get)
+        RouteMatcher.match('/imagesource', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/imageSource"]);
+        ['/imageSource']);
   });
 
-  test("it handles a dodgy getParams request", () {
-    bool hitError = false;
+  test('it handles a dodgy getParams request', () {
+    var hitError = false;
 
     try {
-      RouteMatcher.getParams("/id/:id/abc", "/id/10");
+      RouteMatcher.getParams('/id/:id/abc', '/id/10');
     } on NotMatchingRouteException catch (_) {
       hitError = true;
     }
     expect(hitError, true);
   });
 
-  test("it should ignore a trailing slash", () {
+  test('it should ignore a trailing slash', () {
     final testRoutes = [
-      HttpRoute("/b/", (req, res) async {}, Method.get),
+      HttpRoute('/b/', (req, res) async {}, Method.get),
     ];
 
     expect(
-        RouteMatcher.match("/b?qs=true", testRoutes, Method.get)
+        RouteMatcher.match('/b?qs=true', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/b/"]);
+        ['/b/']);
   });
 
-  test("it should ignore a trailing slash in reverse", () {
+  test('it should ignore a trailing slash in reverse', () {
     final testRoutes = [
-      HttpRoute("/b", (req, res) async {}, Method.get),
+      HttpRoute('/b', (req, res) async {}, Method.get),
     ];
 
     expect(
-        RouteMatcher.match("/b/?qs=true", testRoutes, Method.get)
+        RouteMatcher.match('/b/?qs=true', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/b"]);
+        ['/b']);
   });
 
-  test("it should hit a wildcard route halfway through the uri", () {
+  test('it should hit a wildcard route halfway through the uri', () {
     final testRoutes = [
-      HttpRoute("/route/*", (req, res) async {}, Method.get),
-      HttpRoute("/route/route2", (req, res) async {}, Method.get),
+      HttpRoute('/route/*', (req, res) async {}, Method.get),
+      HttpRoute('/route/route2', (req, res) async {}, Method.get),
     ];
 
     expect(
-        RouteMatcher.match("/route/route2", testRoutes, Method.get)
+        RouteMatcher.match('/route/route2', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/route/*", "/route/route2"]);
+        ['/route/*', '/route/route2']);
   });
 
-  test("it should hit a wildcard route halfway through the uri - sibling", () {
+  test('it should hit a wildcard route halfway through the uri - sibling', () {
     final testRoutes = [
-      HttpRoute("/route*", (req, res) async {}, Method.get),
-      HttpRoute("/route", (req, res) async {}, Method.get),
-      HttpRoute("/route/test", (req, res) async {}, Method.get),
+      HttpRoute('/route*', (req, res) async {}, Method.get),
+      HttpRoute('/route', (req, res) async {}, Method.get),
+      HttpRoute('/route/test', (req, res) async {}, Method.get),
     ];
 
     expect(
-        RouteMatcher.match("/route", testRoutes, Method.get)
+        RouteMatcher.match('/route', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/route*", "/route"]);
+        ['/route*', '/route']);
 
     expect(
-        RouteMatcher.match("/route/test", testRoutes, Method.get)
+        RouteMatcher.match('/route/test', testRoutes, Method.get)
             .map((e) => e.route)
             .toList(),
-        ["/route*", "/route/test"]);
+        ['/route*', '/route/test']);
   });
 }

--- a/tool/generate_readme.dart
+++ b/tool/generate_readme.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 String importExample(String name) =>
-    File("example/$name").readAsStringSync().trim();
+    File('example/$name').readAsStringSync().trim();
 
 void main() {
   final template = """
@@ -220,5 +220,5 @@ ${importExample("example_cors.dart")}
 
   """;
 
-  File("README.md").writeAsStringSync(template.trim());
+  File('README.md').writeAsStringSync(template.trim());
 }


### PR DESCRIPTION
I'll recommend to stick with the default linter rules provided by pedantic. Reason behind this is, that most people (also those who coming from Flutter ecosystem) are used to the default linter rules.

This increases the **readability** and **maintainability** and therefore the **acceptance** of the project.

This PR removes both custom linter rules and apply all necessary fixes to the code.