### PR TITLE
Remove extra async await

### DIFF
--- a/lib/src/extensions/response_helpers.dart
+++ b/lib/src/extensions/response_helpers.dart
@@ -37,15 +37,15 @@ extension ResponseHelpers on HttpResponse {
 
   /// Helper method for those used to res.json()
   ///
-  Future json(Object? json) async {
+  Future json(Object? json) {
     headers.contentType = ContentType.json;
     write(jsonEncode(json));
-    await close();
+    return close();
   }
 
   /// Helper method to just send data;
-  Future send(Object? data) async {
+  Future send(Object? data) {
     write(data);
-    await close();
+    return close();
   }
 }

--- a/lib/src/type_handlers/file_type_handler.dart
+++ b/lib/src/type_handlers/file_type_handler.dart
@@ -6,5 +6,5 @@ import 'type_handler.dart';
 TypeHandler get fileTypeHandler => TypeHandler<File>((req, res, val) async {
       res.setContentTypeFromFile(val);
       await res.addStream(val.openRead());
-      await res.close();
+      return res.close();
     });

--- a/lib/src/type_handlers/json_type_handlers.dart
+++ b/lib/src/type_handlers/json_type_handlers.dart
@@ -4,10 +4,10 @@ import 'dart:io';
 
 import 'package:alfred/src/type_handlers/type_handler.dart';
 
-FutureOr _jsonHandler(req, res, val) async {
+FutureOr _jsonHandler(req, res, val) {
   res.headers.contentType = ContentType.json;
   res.write(jsonEncode(val));
-  await res.close();
+  return res.close();
 }
 
 TypeHandler get jsonMapTypeHandler =>

--- a/lib/src/type_handlers/string_type_handler.dart
+++ b/lib/src/type_handlers/string_type_handler.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:alfred/src/type_handlers/type_handler.dart';
 
 TypeHandler<String> get stringTypeHandler =>
-    TypeHandler<String>((HttpRequest req, HttpResponse res, value) async {
+    TypeHandler<String>((HttpRequest req, HttpResponse res, value) {
       res.write(value);
-      await res.close();
+      return res.close();
     });

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -11,15 +11,13 @@ void main() {
   late Alfred app;
   late int port;
 
-  setUp(() async {
+  setUp(() {
     port = Random().nextInt(65535 - 1024) + 1024;
     app = Alfred();
-    await app.listen(port);
+    return app.listen(port);
   });
 
-  tearDown(() async {
-    await app.close();
-  });
+  tearDown(() => app.close());
 
   test("it should return a string correctly", () async {
     app.get("/test", (req, res) => "test string");


### PR DESCRIPTION
Since the function already returns the future, there is no point in waiting for its completion, and it can be passed on.