### PR TITLE
avoid using late modifier for Alfred.queue

### DIFF
--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -51,7 +51,7 @@ class Alfred {
   ///
   /// Set the number of simultaneous connections being processed at any one time
   /// in the [simultaneousProcessing] param in the constructor
-  late Queue requestQueue;
+  Queue requestQueue;
 
   /// An array of [TypeHandler] that Alfred walks through in order to determine
   /// if it can handle a value returned from a route.
@@ -87,8 +87,7 @@ class Alfred {
     this.onInternalError,
     this.logRequests = true,
     int simultaneousProcessing = 50,
-  }) {
-    requestQueue = Queue(parallel: simultaneousProcessing);
+  }) : requestQueue = Queue(parallel: simultaneousProcessing) {
     _registerDefaultTypeHandlers();
     _registerPluginListeners();
   }


### PR DESCRIPTION
We can initialize any non-null or final class fields after the `:`, right before constructor body.
Therefore we can omit the `late` keyword and be "clean".

This PR applys necessary changes to do that.