### PR TITLE
SPA support / Less aggressive DirectoryTypeHandler

### DIFF
--- a/example/example_single_page_application.dart
+++ b/example/example_single_page_application.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:alfred/alfred.dart';
+
+Future<void> main() async {
+  final app = Alfred();
+
+  // Provide any static assets
+  app.get('/frontend/*', (req, res) => Directory('spa'));
+
+  // Let any other routes handle by client SPA
+  app.get('/frontend/*', (req, res) => File('spa/index.html'));
+
+  await app.listen();
+}

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -28,8 +28,8 @@ class RouteMatcher {
       /// Wildcard describes sub-path
       ///
       if (item.route.endsWith('/*')) {
-        final routeWithoutSlash =
-            item.route.normalizePath.substring(0, item.route.normalizePath.length - '/*'.length);
+        final routeWithoutSlash = item.route.normalizePath
+            .substring(0, item.route.normalizePath.length - '/*'.length);
         var normalizedInput = input.normalizePath;
         if (normalizedInput.startsWith(routeWithoutSlash)) {
           output.add(item);

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -25,6 +25,18 @@ class RouteMatcher {
         continue;
       }
 
+      /// Wildcard describes sub-path
+      ///
+      if (item.route.endsWith('/*')) {
+        final routeWithoutSlash =
+            item.route.normalizePath.substring(0, item.route.normalizePath.length - '/*'.length);
+        var normalizedInput = input.normalizePath;
+        if (normalizedInput.startsWith(routeWithoutSlash)) {
+          output.add(item);
+          continue;
+        }
+      }
+
       final itemParts = List<String>.from(Uri.parse(item.route).pathSegments);
 
       if (itemParts.isNotEmpty && itemParts.last == '') {
@@ -90,6 +102,19 @@ class RouteMatcher {
       }
     }
     return output;
+  }
+}
+
+extension _PathNormalizer on String {
+  /// Trims all slashes at the start and end
+  String get normalizePath {
+    if (startsWith('/')) {
+      return substring('/'.length).normalizePath;
+    }
+    if (endsWith('/')) {
+      return substring(0, length - '/'.length).normalizePath;
+    }
+    return this;
   }
 }
 

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -286,12 +286,14 @@ void main() {
     expect(r2.headers['content-type'], 'text/html');
     expect(r2.body.contains('I am a SPA Application'), true);
 
-    final r3 = await http.get(Uri.parse('http://localhost:$port/spa/index.html'));
+    final r3 =
+        await http.get(Uri.parse('http://localhost:$port/spa/index.html'));
     expect(r3.statusCode, 200);
     expect(r3.headers['content-type'], 'text/html');
     expect(r3.body.contains('I am a SPA Application'), true);
 
-    final r4 = await http.get(Uri.parse('http://localhost:$port/spa/assets/some.txt'));
+    final r4 =
+        await http.get(Uri.parse('http://localhost:$port/spa/assets/some.txt'));
     expect(r4.statusCode, 200);
     expect(r4.headers['content-type'], 'text/plain');
     expect(r4.body.contains('This is some txt'), true);

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -270,11 +270,31 @@ void main() {
         await http.get(Uri.parse('http://localhost:$port/files/dummy.pdf'));
     expect(response.statusCode, 200);
     expect(response.headers['content-type'], 'application/pdf');
+  });
 
-    final responseNotFound = await http
-        .get(Uri.parse('http://localhost:$port/files/doesnotexist.png'));
-    expect(responseNotFound.statusCode, 404);
-    expect(responseNotFound.body, '{"message":"file not found"}');
+  test('it serves SPA projects', () async {
+    app.get('/spa/*', (req, res) => Directory('test/files/spa'));
+    app.get('/spa/*', (req, res) => File('test/files/spa/index.html'));
+
+    final r1 = await http.get(Uri.parse('http://localhost:$port/spa'));
+    expect(r1.statusCode, 200);
+    expect(r1.headers['content-type'], 'text/html');
+    expect(r1.body.contains('I am a SPA Application'), true);
+
+    final r2 = await http.get(Uri.parse('http://localhost:$port/spa/'));
+    expect(r2.statusCode, 200);
+    expect(r2.headers['content-type'], 'text/html');
+    expect(r2.body.contains('I am a SPA Application'), true);
+
+    final r3 = await http.get(Uri.parse('http://localhost:$port/spa/index.html'));
+    expect(r3.statusCode, 200);
+    expect(r3.headers['content-type'], 'text/html');
+    expect(r3.body.contains('I am a SPA Application'), true);
+
+    final r4 = await http.get(Uri.parse('http://localhost:$port/spa/assets/some.txt'));
+    expect(r4.statusCode, 200);
+    expect(r4.headers['content-type'], 'text/plain');
+    expect(r4.body.contains('This is some txt'), true);
   });
 
   test('it routes correctly for a / url', () async {

--- a/test/files/spa/assets/some.txt
+++ b/test/files/spa/assets/some.txt
@@ -1,0 +1,1 @@
+This is some txt

--- a/test/files/spa/index.html
+++ b/test/files/spa/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Framework</title>
+</head>
+<body>
+I am a SPA Application handling routing.
+</body>
+</html>

--- a/test/route_matcher_test.dart
+++ b/test/route_matcher_test.dart
@@ -69,6 +69,19 @@ void main() {
         ['*', '/a']);
   });
 
+  test('it should generously match wildcards for sub-paths', () {
+    final testRoutes = [
+      HttpRoute('path/*', (req, res) async {}, Method.get),
+    ];
+
+    expect(
+        RouteMatcher.match('/path/to', testRoutes, Method.get).isNotEmpty, true);
+    expect(
+        RouteMatcher.match('/path/', testRoutes, Method.get).isNotEmpty, true);
+    expect(
+        RouteMatcher.match('/path', testRoutes, Method.get).isNotEmpty, true);
+  });
+
   test('it should respect the routemethod', () {
     final testRoutes = [
       HttpRoute('*', (req, res) async {}, Method.post),

--- a/test/route_matcher_test.dart
+++ b/test/route_matcher_test.dart
@@ -74,8 +74,8 @@ void main() {
       HttpRoute('path/*', (req, res) async {}, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/path/to', testRoutes, Method.get).isNotEmpty, true);
+    expect(RouteMatcher.match('/path/to', testRoutes, Method.get).isNotEmpty,
+        true);
     expect(
         RouteMatcher.match('/path/', testRoutes, Method.get).isNotEmpty, true);
     expect(


### PR DESCRIPTION
This PR adds support for SPA application.

**Notable changes:**
__
`DirectoryTypeHandler` doesn't freak out if he doesn't find a file. If Alfred solely serves static assets the `onNotFound` handler should take care of 404s as referenced in #22 
__
`DirectoryTypeHandler` now operates on a list of possible candidates. This allows Alfred to serve `index.html` when the request URI addresses just a path to a directory, that contains an `index.html`.
```dart
app.get('/frontend/*', (req, res) => Directory('spa'));
// 'GET /frontend/' will respond with '/spa/index.html'
```
__
`RouteMatcher` will generously match wildcards on sub-paths.
```dart
app.get('/foo/*', (req, res) => 'response');
// matches 'GET /foo/bar'
// matches 'GET /foo/'
// matches 'GET /foo'
```
__
Added example `example_single_page_application.dart` that demonstrates SPA configuration with Alfred.