### PR TITLE
Prevent full crash

### DIFF
--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -294,9 +294,11 @@ class Alfred {
         await request.response.close();
       } else {
         //Otherwise fall back to a generic 500 error
-        request.response.statusCode = 500;
-        request.response.write(e);
-        await request.response.close();
+        try {
+          request.response.statusCode = 500;
+          request.response.write(e);
+          await request.response.close();
+        } catch (_) {}
       }
     }
   }

--- a/lib/src/type_handlers/file_type_handler.dart
+++ b/lib/src/type_handlers/file_type_handler.dart
@@ -6,7 +6,9 @@ import 'type_handler.dart';
 TypeHandler get fileTypeHandler =>
     TypeHandler<File>((HttpRequest req, HttpResponse res, dynamic val) async {
       val = val as File;
-      res.setContentTypeFromFile(val);
-      await res.addStream(val.openRead());
-      return res.close();
+      if (val.existsSync()) {
+        res.setContentTypeFromFile(val);
+        await res.addStream(val.openRead());
+        return res.close();
+      }
     });

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -277,6 +277,15 @@ void main() {
     expect(responseNotFound.body, '{"message":"file not found"}');
   });
 
+  test('it does not crash when File not exists', () async {
+    app.get('error', (req, res) => File('does-not-exists'));
+    app.get('works', (req, res) => 'works!');
+
+    await http.get(Uri.parse('http://localhost:$port/error'));
+    final request = await http.get(Uri.parse('http://localhost:$port/works'));
+    expect(request.statusCode, 200);
+  });
+
   test('it routes correctly for a / url', () async {
     app.get('/', (req, res) => 'working');
     final response = await http.get(Uri.parse('http://localhost:$port/'));


### PR DESCRIPTION
Alfred can be fully crashed by an off-thread exception. Example:
```dart
import 'dart:io';

import 'package:alfred/alfred.dart';

Future<void> main() async {
  final app = Alfred();

  app.all('*', (req, res) => File('not-found'));

  final server = await app.listen();

  print('Listening on ${server.port}');
}
```
The last resort error handling throws error if headers are already set, which leads to a full crash:
```dart
//Otherwise fall back to a generic 500 error
request.response.statusCode = 500;
request.response.write(e);
await request.response.close();
```

This PR fixes this. Also it adds a check if a requested File exists.