### PR TITLE
make get() also use _createRoute()

### DIFF
--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -112,13 +112,10 @@ class Alfred {
   /// Create a get route
   ///
   HttpRoute get(String path,
-      FutureOr Function(HttpRequest req, HttpResponse res) callback,
-      {List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
-          const []}) {
-    final route = HttpRoute(path, callback, Method.get, middleware: middleware);
-    routes.add(route);
-    return route;
-  }
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.get, middleware);
 
   /// Create a post route
   ///


### PR DESCRIPTION
The `Alfred.get()` method doesn't use the `_createRoute()` method like it's siblings.

This PR fixes that.