### PR TITLE
add support for nested routes

### DIFF
--- a/lib/alfred.dart
+++ b/lib/alfred.dart
@@ -4,6 +4,7 @@ export 'package:http_server/http_server.dart' show HttpBodyFileUpload;
 
 export 'src/alfred.dart';
 export 'src/alfred_exception.dart';
+export 'src/extensions/nested_route.dart';
 export 'src/extensions/file_helpers.dart';
 export 'src/extensions/request_helpers.dart';
 export 'src/extensions/response_helpers.dart';

--- a/lib/src/extensions/nested_route.dart
+++ b/lib/src/extensions/nested_route.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import '../../alfred.dart';
+
+extension NestedRouteExtension on Alfred {
+  /// Creates one or multiple route segments that can be used
+  /// as a common base for specifying routes with [get], [post], etc.
+  ///
+  /// You can define middleware that effects all sub-routes.
+  NestedRoute route(String path,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      NestedRoute(alfred: this, basePath: path, baseMiddleware: middleware);
+}
+
+class NestedRoute {
+  final Alfred _alfred;
+  final String _basePath;
+  final List<FutureOr Function(HttpRequest req, HttpResponse res)>
+      _baseMiddleware;
+
+  NestedRoute(
+      {required Alfred alfred,
+      required String basePath,
+      required List<FutureOr Function(HttpRequest req, HttpResponse res)>
+          baseMiddleware})
+      : _alfred = alfred,
+        _basePath = basePath,
+        _baseMiddleware = baseMiddleware;
+
+  /// Create a get route
+  ///
+  HttpRoute get(String path,
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.get, middleware);
+
+  /// Create a post route
+  ///
+  HttpRoute post(String path,
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.post, middleware);
+
+  /// Create a put route
+  HttpRoute put(String path,
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.put, middleware);
+
+  /// Create a delete route
+  ///
+  HttpRoute delete(String path,
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.delete, middleware);
+
+  /// Create a patch route
+  ///
+  HttpRoute patch(String path,
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.patch, middleware);
+
+  /// Create an options route
+  ///
+  HttpRoute options(String path,
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.options, middleware);
+
+  /// Create a route that listens on all methods
+  ///
+  HttpRoute all(String path,
+          FutureOr Function(HttpRequest req, HttpResponse res) callback,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      _createRoute(path, callback, Method.all, middleware);
+
+  /// Creates one or multiple route segments that can be used
+  /// as a common base for specifying routes with [get], [post], etc.
+  ///
+  /// You can define middleware that effects all sub-routes.
+  NestedRoute route(String path,
+          {List<FutureOr Function(HttpRequest req, HttpResponse res)>
+              middleware = const []}) =>
+      NestedRoute(
+          alfred: _alfred,
+          basePath: _composePath(_basePath, path),
+          baseMiddleware: [..._baseMiddleware, ...middleware]);
+
+  HttpRoute _createRoute(
+      String path,
+      FutureOr Function(HttpRequest req, HttpResponse res) callback,
+      Method method,
+      [List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
+          const []]) {
+    final route = HttpRoute(_composePath(_basePath, path), callback, method,
+        middleware: [..._baseMiddleware, ...middleware]);
+    _alfred.routes.add(route);
+    return route;
+  }
+}
+
+String _composePath(String first, String second) {
+  if (first.endsWith('/') && second.startsWith('/')) {
+    return first + second.substring(1);
+  } else if (!first.endsWith('/') && !second.startsWith('/')) {
+    return first + '/' + second;
+  }
+  return first + second;
+}

--- a/test/nested_route_test.dart
+++ b/test/nested_route_test.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alfred/alfred.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Alfred app;
+
+  setUp(() {
+    app = Alfred();
+  });
+
+  test('it can compose requests', () async {
+    var path = app.route('path');
+    path.get('a', _callback);
+    path.post('b', _callback);
+    path.put('c', _callback);
+    path.patch('d', _callback);
+    path.delete('e', _callback);
+    path.options('f', _callback);
+    path.all('g', _callback);
+
+    expect(app.routes.map((r) => '${r.route}:${r.method}').toList(), [
+      'path/a:Method.get',
+      'path/b:Method.post',
+      'path/c:Method.put',
+      'path/d:Method.patch',
+      'path/e:Method.delete',
+      'path/f:Method.options',
+      'path/g:Method.all',
+    ]);
+  });
+
+  test('it can compose multiple times', () async {
+    app.route('first/and').route('second/and').get('third', _callback);
+    expect(app.routes.first.route, 'first/and/second/and/third');
+  });
+
+  test('it can handle slashes when composing', () async {
+    app.route('first/').get('/second', _callback);
+    app.route('first').get('/second', _callback);
+    app.route('first/').get('second', _callback);
+    app.route('first').get('second', _callback);
+    expect(app.routes.length, 4);
+    for (var route in app.routes) {
+      expect(route.route, 'first/second');
+    }
+  });
+
+  test('it can correctly inherit middleware', () async {
+    var mw1 = _callback;
+    var mw2 = _callback;
+
+    var first = app.route('first', middleware: [mw1]);
+    first.get('a', _callback);
+    first.get('b', _callback);
+
+    var second = first.route('second', middleware: [mw2]);
+    second.get('c', _callback);
+
+    expect(app.routes.length, 3);
+
+    expect(app.routes[0].route, 'first/a');
+    expect(app.routes[0].middleware, [mw1]);
+
+    expect(app.routes[1].route, 'first/b');
+    expect(app.routes[1].middleware, [mw1]);
+
+    expect(app.routes[2].route, 'first/second/c');
+    expect(app.routes[2].middleware, [mw1, mw2]);
+  });
+}
+
+FutureOr Function(HttpRequest, HttpResponse) get _callback => (req, res) {};


### PR DESCRIPTION
This PR implements nested routes. This implementation only relies on extension functions, without touching Alfred's core, which is a good indicator for an extensible architecture :-)

You can do things like
```dart
import 'package:alfred/alfred.dart';

Future<void> main() async {
  var app = Alfred();
  var personRepository = app.route('/person/', middleware: [onlyAuthed]);

  personRepository.post('', addPersonCallback);
  personRepository.get('', listAllPersonCallback);
  personRepository.get(':id', getPersonCallback);
  personRepository.put(':id', updatePersonCallback);
  personRepository.delete(':id', removePersonCallback);
}
```

The middleware gets fully inherited:
```dart
import 'package:alfred/alfred.dart';

Future<void> main() async {
  var app = Alfred();

  var api = app.route('api/v1', middleware: [cors]);

  var person = api.route('person', middleware: [onlyAuthed]);
  person.get(':id', getPersonCallback); // uses 'cors' and 'onlyAuthed'
}
```

I didn't provided any readme/examples cause I wanted to await your opinion on syntax, terms and if it's a good idea.