### PR TITLE
add websocket support

### DIFF
--- a/example/example_websocket/chat-client.html
+++ b/example/example_websocket/chat-client.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>WebSocket</title>
+    <style>
+        body {font-family: sans-serif;}
+        #messages {background: #d8edf5; border-radius: 8px; min-height: 100px; margin-bottom: 8px; display: flex; flex-direction: column;}
+        #messages div {background: #eff6f8; border-radius: 8px;  margin: 8px; padding: 6px 12px; display: inline-block; width: fit-content}
+    </style>
+</head>
+<body>
+
+<div id="messages"></div>
+
+<div class="panel">
+    <label>Type message and hit <i>&lt;Enter&gt;</i>: <input autofocus id="input" type="text"></label>
+</div>
+
+<script type="module">
+    document.addEventListener('DOMContentLoaded', () => {
+        const input = document.querySelector('#input');
+        const messages = document.querySelector('#messages');
+
+        const socket = new WebSocket(`ws://${location.host}/ws`);
+
+        socket.onopen = () => {
+            console.log('WebSocket connection established.');
+        }
+
+        socket.onmessage = (e) => {
+            const el = document.createElement('div');
+            el.innerText = e.data;
+            messages.appendChild(el);
+        }
+
+        socket.onclose = () => {
+            console.log('WebSocket connection closed');
+        }
+
+        socket.onerror = () => {
+            location.reload();
+        }
+
+
+        input.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter' && input.value.length > 0) {
+                socket.send(input.value);
+                input.value = '';
+            }
+        });
+    })
+</script>
+
+</body>
+</html>

--- a/example/example_websocket/example_websocket.dart
+++ b/example/example_websocket/example_websocket.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alfred/alfred.dart';
+import 'package:alfred/src/type_handlers/websocket_type_handler.dart';
+
+Future<void> main() async {
+  final app = Alfred();
+
+  // Path to this Dart file
+  var dir = File(Platform.script.path).parent.path;
+
+  // Deliver web client for chat
+  app.get('/', (req, res) => File('$dir/chat-client.html'));
+
+  // Track connected clients
+  var users = <WebSocket>[];
+
+  // WebSocket chat relay implementation
+  app.get('/ws', (req, res) {
+    return WebSocketSession(
+      onOpen: (ws) {
+        users.add(ws);
+        users
+            .where((user) => user != ws)
+            .forEach((user) => user.send('A new user joined the chat.'));
+      },
+      onClose: (ws) {
+        users.remove(ws);
+        users.forEach((user) => user.send('A user has left.'));
+      },
+      onMessage: (ws, dynamic data) async {
+        users.forEach((user) => user.send(data));
+      },
+    );
+  });
+
+  final server = await app.listen();
+
+  print('Listening on ${server.port}');
+}

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -8,6 +8,7 @@ import 'package:alfred/src/type_handlers/file_type_handler.dart';
 import 'package:alfred/src/type_handlers/json_type_handlers.dart';
 import 'package:alfred/src/type_handlers/string_type_handler.dart';
 import 'package:alfred/src/type_handlers/type_handler.dart';
+import 'package:alfred/src/type_handlers/websocket_type_handler.dart';
 import 'package:enum_to_string/enum_to_string.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:queue/queue.dart';
@@ -101,7 +102,8 @@ class Alfred {
       jsonListTypeHandler,
       jsonMapTypeHandler,
       fileTypeHandler,
-      directoryTypeHandler
+      directoryTypeHandler,
+      websocketTypeHandler
     ]);
   }
 

--- a/lib/src/type_handlers/websocket_type_handler.dart
+++ b/lib/src/type_handlers/websocket_type_handler.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alfred/src/type_handlers/type_handler.dart';
+
+TypeHandler<WebSocketSession> get websocketTypeHandler =>
+    TypeHandler<WebSocketSession>(
+        (HttpRequest req, HttpResponse res, dynamic value) async {
+      value = value as WebSocketSession;
+      var ws = await WebSocketTransformer.upgrade(req);
+      value._start(ws);
+    });
+
+/// Convenience wrapper around Dart IO WebSocket implementation
+class WebSocketSession {
+  late WebSocket socket;
+
+  FutureOr<void> Function(WebSocket webSocket)? onOpen;
+  FutureOr<void> Function(WebSocket webSocket, dynamic data)? onMessage;
+  FutureOr<void> Function(WebSocket webSocket)? onClose;
+  FutureOr<void> Function(WebSocket webSocket, dynamic error)? onError;
+
+  WebSocketSession({this.onOpen, this.onMessage, this.onClose, this.onError});
+
+  void _start(WebSocket webSocket) {
+    socket = webSocket;
+    try {
+      if (onOpen != null) {
+        onOpen!(socket);
+      }
+      socket.listen((dynamic data) {
+        if (onMessage != null) {
+          onMessage!(socket, data);
+        }
+      }, onDone: () {
+        if (onClose != null) {
+          onClose!(socket);
+        }
+      }, onError: (dynamic error) {
+        if (onError != null) {
+          onError!(socket, error);
+        }
+      });
+    } catch (e) {
+      print('WebSocket Error: $e');
+      try {
+        socket.close();
+        // ignore: empty_catches
+      } catch (e) {}
+    }
+  }
+}
+
+extension WebSocketHelper on WebSocket {
+  /// Sends data to the client
+  void send(dynamic data) => add(data);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,4 +16,5 @@ dependencies:
 
 dev_dependencies:
   test: ^1.14.4
+  web_socket_channel: ^2.0.0
   http:

--- a/test/websocket_test.dart
+++ b/test/websocket_test.dart
@@ -1,0 +1,50 @@
+import 'dart:math';
+
+import 'package:alfred/alfred.dart';
+import 'package:alfred/src/type_handlers/websocket_type_handler.dart';
+import 'package:test/test.dart';
+import 'package:web_socket_channel/io.dart';
+
+void main() {
+  late Alfred app;
+  late int port;
+
+  setUp(() {
+    port = Random().nextInt(65535 - 1024) + 1024;
+    app = Alfred();
+    return app.listen(port);
+  });
+
+  tearDown(() => app.close());
+
+  test('it can handle websockets', () async {
+    var opened = false;
+    var closed = false;
+    String? message;
+
+    app.get(
+        '/ws',
+        (req, res) => WebSocketSession(
+              onOpen: (ws) => opened = true,
+              onClose: (ws) => closed = true,
+              onMessage: (ws, dynamic data) {
+                message = data as String;
+                ws.send('echo $data');
+              },
+            ));
+
+    final channel = IOWebSocketChannel.connect('ws://localhost:$port/ws');
+
+    channel.sink.add('hi');
+
+    var response = (await channel.stream.first) as String;
+    expect(opened, true);
+    expect(closed, false);
+    expect(message, 'hi');
+    expect(response, 'echo hi');
+
+    await channel.sink.close();
+    await Future<void>.delayed(Duration(milliseconds: 10));
+    expect(closed, true);
+  });
+}


### PR DESCRIPTION
This adds WebSocket support. It's fully relying on Dart IO implementation of websockets. It adds a convenience TypeHandler that mimes the JavaScript API.

Example usage:
```dart
  // Track connected clients
  var users = <WebSocket>[];

  // WebSocket chat relay implementation
  app.get('/ws', (req, res) {
    return WebSocketSession(
      onOpen: (ws) {
        users.add(ws);
        users
            .where((user) => user != ws)
            .forEach((user) => user.send('A new user joined the chat.'));
      },
      onClose: (ws) {
        users.remove(ws);
        users.forEach((user) => user.send('A user has left.'));
      },
      onMessage: (ws, dynamic data) async {
        users.forEach((user) => user.send(data));
      },
    );
  });
```
I also added a simple chat example.