### PR TITLE
refactored store plugin

### DIFF
--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -12,7 +12,6 @@ import 'package:alfred/src/type_handlers/websocket_type_handler.dart';
 import 'package:enum_to_string/enum_to_string.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:queue/queue.dart';
-import 'package:uuid/uuid.dart';
 
 import 'alfred_exception.dart';
 import 'http_route.dart';
@@ -195,7 +194,6 @@ class Alfred {
   ///
   Future<void> _incomingRequest(HttpRequest request) async {
     var isDone = false;
-    request.response.headers.set('x-alfred-requestid', Uuid().v4());
 
     if (logRequests) {
       print('${request.method} - ${request.uri.toString()}');
@@ -241,7 +239,7 @@ class Alfred {
           if (isDone) {
             break;
           }
-          request.setStoreValue('_internal_route', route.route);
+          request.store.set('_internal_route', route.route);
 
           /// Loop through any middleware
           for (var middleware in route.middleware) {

--- a/lib/src/extensions/request_helpers.dart
+++ b/lib/src/extensions/request_helpers.dart
@@ -24,9 +24,5 @@ extension RequestHelpers on HttpRequest {
 
   /// Get the matched route of the current request
   ///
-  String get route => getStoreValue('_internal_route') as String? ?? '';
-
-  /// The request id is used to write plugins that handle logic outside of the
-  /// response and request cycle
-  String get requestId => response.headers.value('x-alfred-requestid')!;
+  String get route => store.get<String?>('_internal_route') ?? '';
 }

--- a/lib/src/plugins/store_plugin.dart
+++ b/lib/src/plugins/store_plugin.dart
@@ -1,20 +1,44 @@
 import 'package:alfred/alfred.dart';
 
-final _store = <String, Map<String, dynamic>>{};
+/// Data structure to keep all request-related data
+final storePluginData = <HttpRequest, RequestStore>{};
 
+/// Integrates [RequestStore] mechanism on [HttpRequest]
 extension StorePlugin on HttpRequest {
-  void setStoreValue(String key, dynamic value) {
-    _store[requestId] ??= <String, dynamic>{};
-    _store[requestId]![key] = value;
+  /// Returns the [RequestStore] dedicated to this request.
+  RequestStore get store {
+    storePluginData[this] ??= RequestStore();
+    return storePluginData[this]!;
   }
-
-  dynamic getStoreValue(String key) => (_store[requestId])?[key];
 }
 
-extension StorePluginData on Alfred {
-  List<String> get storeOutstandingRequests => _store.keys.toList();
+/// Key-Value-Store for reading and writing request-related data
+class RequestStore {
+  final _data = <String, dynamic>{};
+
+  /// Stores a [value] associated with a specified [key].
+  ///
+  /// Example:
+  /// ```dart
+  /// req.store.set('foo', Foo());
+  /// ```
+  void set(String key, dynamic value) => _data[key] = value;
+
+  /// Returns the stored value that has been associated with the specified [key].
+  /// Returns `null` if no value has been written.
+  ///
+  /// Example:
+  /// ```dart
+  /// var foo = req.store.get<Foo>('foo');
+  /// ```
+  T get<T>(String key) {
+    assert(_data[key] is T, 'Store value for key $key does not match type $T');
+    return _data[key] as T;
+  }
 }
 
+/// Used within [Alfred] to remove request-related data after
+/// the request has been resolved.
 void storePluginOnDoneHandler(HttpRequest req, HttpResponse res) {
-  _store.remove(req.requestId);
+  storePluginData.remove(req);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   enum_to_string: ^2.0.1
   queue: ^3.0.0-nullsafety.0
   pedantic: ^1.9.0
-  uuid: ^3.0.3
 
 dev_dependencies:
   test: ^1.14.4

--- a/test/plugins/store_plugin_test.dart
+++ b/test/plugins/store_plugin_test.dart
@@ -22,8 +22,8 @@ void main() {
     var didHit = false;
     app.all('/test', (req, res) {
       expect(req.route, '/test');
-      req.setStoreValue('testValue', 'bah!');
-      expect(req.getStoreValue('testValue'), 'bah!');
+      req.store.set('testValue', 'bah!');
+      expect(req.store.get<String>('testValue'), 'bah!');
       didHit = true;
       return 'done';
     });
@@ -43,19 +43,21 @@ void main() {
     app.removeOnDoneListener(listener);
     await http.get(Uri.parse('http://localhost:$port/test'));
     expect(hitCount, 1);
-    expect(app.storeOutstandingRequests.isEmpty, true);
+    expect(_outstandingRequests.isEmpty, true);
   });
 
   test('the store is correctly available across multiple routes', () async {
     var didHit = false;
     app.get('*', (req, res) {
-      req.setStoreValue('userid', '123456');
+      req.store.set('userid', '123456');
     });
     app.get('/user', (req, res) {
       didHit = true;
-      expect(req.getStoreValue('userid'), '123456');
+      expect(req.store.get<String>('userid'), '123456');
     });
     await http.get(Uri.parse('http://localhost:$port/user'));
     expect(didHit, true);
   });
 }
+
+List<HttpRequest> get _outstandingRequests => storePluginData.keys.toList();


### PR DESCRIPTION
I refactored the store plugin. It's basically @rknell 's core concept with some syntactic sugar.

I was able to remove the `x-alfred-requestid`. The fact that Alfred needs to add a mandatory request identifier and therefore forcibly expose itself towards the client, felt bad. We can just use the bare `HttpRequest` objects as `Map`-keys which have an own identifier (`object.hashCode`).

The new API looks like this:
```dart
final app = Alfred();

app.all('*', (req, res) {
  req.store.set('foo', Foo());
});

app.get('/some-value', (req, res) async {
  var foo = req.store.get<Foo>('foo');
  return foo.bar();
});
```

The `get<T>()` method has some type generics to avoid manual casting.

Also the `store` getter is backed up by a `RequestStore` class, that can also be used in apps as an additional reference point for extension methods, if needed:

```dart
extension AccessFoo on RequestStore {
  Foo get foo => get<Foo>('foo');
}

Future<void> main() async {
  final app = Alfred();

  app.all('*', (req, res) {
    req.store.set('foo', Foo());
  });

  app.get('/some-value', (req, res) async {
    return req.store.foo.bar();
  });
  
  //...
}
```

