### PR TITLE
implemented custom logging

### DIFF
--- a/example/example_custom_logging.dart
+++ b/example/example_custom_logging.dart
@@ -19,7 +19,7 @@ void main() {
   app.logWriter = (messageFn, type) {
     switch (type) {
       case LogType.debug:
-        // avoid evaluating too much debugs messages
+        // avoid evaluating too much debug messages
         if (log.level <= Level.FINE) {
           log.fine(messageFn());
         }

--- a/example/example_custom_logging.dart
+++ b/example/example_custom_logging.dart
@@ -19,7 +19,10 @@ void main() {
   app.logWriter = (messageFn, type) {
     switch (type) {
       case LogType.debug:
-        log.fine(messageFn());
+        // avoid evaluating too much debugs messages
+        if (log.level <= Level.FINE) {
+          log.fine(messageFn());
+        }
         break;
       case LogType.info:
         log.info(messageFn());
@@ -34,6 +37,7 @@ void main() {
   };
 
   // Configure routing...
+  app.get('/resource', (req, res) => 'response');
 
   app.listen();
 }

--- a/example/example_custom_logging.dart
+++ b/example/example_custom_logging.dart
@@ -1,0 +1,39 @@
+import 'package:alfred/alfred.dart';
+import 'package:logging/logging.dart';
+
+// Use 'logging' package instead of default logger
+
+void main() {
+  var app = Alfred();
+
+  // Configure root logger
+  Logger.root.level = Level.ALL; // defaults to Level.INFO
+  Logger.root.onRecord.listen((record) {
+    print('${record.level.name}: ${record.time}: ${record.message}');
+  });
+
+  // Create logger for Alfred app
+  var log = Logger('HttpServer');
+
+  // Create custom logWriter and map to logging package
+  app.logWriter = (messageFn, type) {
+    switch (type) {
+      case LogType.debug:
+        log.fine(messageFn());
+        break;
+      case LogType.info:
+        log.info(messageFn());
+        break;
+      case LogType.warn:
+        log.warning(messageFn());
+        break;
+      case LogType.error:
+        log.severe(messageFn());
+        break;
+    }
+  };
+
+  // Configure routing...
+
+  app.listen();
+}

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -108,10 +108,12 @@ class Alfred {
   }
 
   void _registerDefaultLogWriter(LogType logLevel) {
-    logWriter = (dynamic messageFn, type) {
+    logWriter = (dynamic Function() messageFn, type) {
       if (type.index >= logLevel.index) {
-        print(
-            '${DateTime.now()} - ${EnumToString.convertToString(type)} - ${messageFn()}');
+        var timestamp = DateTime.now();
+        var logType = EnumToString.convertToString(type);
+        var message = messageFn().toString();
+        print('$timestamp - $logType - $message');
       }
     };
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,4 +16,5 @@ dependencies:
 dev_dependencies:
   test: ^1.14.4
   web_socket_channel: ^2.0.0
+  logging: ^1.0.1
   http:

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -339,6 +339,22 @@ void main() {
     expect(response.statusCode, 500);
     expect(response.body.contains('_UnknownType'), true);
   });
+
+  test('it should log out request information', () async {
+    app.get('/resource', (req, res) => 'response', middleware: [cors()]);
+    var logs = <String>[];
+    app.logWriter = (msgFn, type) => logs.add('$type ${msgFn()}');
+    await http.get(Uri.parse('http://localhost:$port/resource'));
+
+    bool inLog(String part) =>
+        logs.isNotEmpty && logs.where((log) => log.contains(part)).isNotEmpty;
+
+    expect(inLog('info GET - /resource'), true);
+    expect(inLog('debug Match route: /resource'), true);
+    expect(inLog('debug Apply middleware'), true);
+    expect(inLog('debug Apply TypeHandler for result type: String'), true);
+    expect(inLog('debug Response sent to client'), true);
+  });
 }
 
 class _UnknownType {}


### PR DESCRIPTION
PR extends Alfred logging capabilities.

- Removes forced `print()` calls
- The `logWriter` function can delegate log messages and can be used as adapter for 3rd party logging solutions (example provided / added `dev_dependency` is used for the example)
- Contains dependency-less default `logWriter` implementation that can be controlled via `logLevel` constructor parameter
- Added some `debug`-level logs

The `logWriter` signature uses `String Function() messageFn` to avoid producing log-`String`s that will be discarded because of the log level.