### PR TITLE
enhanced readme / documentation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A performant, express like server framework with a few bonuses that make life ev
 [![Build Status](https://travis-ci.org/rknell/alfred.svg?branch=master)](https://travis-ci.org/rknell/alfred)
 
 Quickstart:
+
 ```dart
 import 'package:alfred/alfred.dart';
 
@@ -14,15 +15,13 @@ void main() async {
   app.get('/example', (req, res) => 'Hello world');
 
   await app.listen();
-
-  print('Listening on port 3000');
 }
-``` 
+```
 
 ## Motivation and philosophy
 
-TlDr:  
-- A minimum of dependencies, 
+TlDr:
+- A minimum of dependencies,
 - A minimum of code (199 lines at last check), and sticking close to dart core libraries
 - Ease of use
 - Predictable, well established semantics
@@ -31,8 +30,8 @@ I came to dart with a NodeJS / React Native & Cordova background. Previously I h
 my server framework, almost always calling "res.json()". I just wanted a simple framework that would
 allow me to pump out apps using dart on the server.
 
-I started with Aqueduct - It seemed like it was the most popular and better supported of the ones I 
-looked at. Aqueduct caused a bunch of errors that were nearly impossible to debug after you scratched 
+I started with Aqueduct - It seemed like it was the most popular and better supported of the ones I
+looked at. Aqueduct caused a bunch of errors that were nearly impossible to debug after you scratched
 the surface.
 
 Then I moved to Angel. Angel seemed a little less popular but concerned me because it was trying to
@@ -210,7 +209,7 @@ provides over the core library is the routing and route param extraction.
 
 ## Routing
 
-Routing follows a similar pattern to the more basic ExpressJS routes. While there is some regex 
+Routing follows a similar pattern to the more basic ExpressJS routes. While there is some regex
 matching, mostly just stick with the route name and param syntax from Express:
 
 "/path/to/:id/property" etc
@@ -317,16 +316,14 @@ If you return null it will yield to the next middleware or route.
 
 ## Error handling
 
-You can either set the status code on the response object yourself and send the data manually, or 
+You can either set the status code on the response object yourself and send the data manually, or
 you can do this from any route:
 
-```dart
 app.get("/",(req, res) => throw AlfredException(400, {"message": "invalid request"}));
-```
 
 If any of the routes bubble an unhandled error, it will catch it and throw a 500 error.
 
-If you want to handle the logic when a 500 error is thrown, you can add a custom handler when you 
+If you want to handle the logic when a 500 error is thrown, you can add a custom handler when you
 instantiate the app. For example:
 
 ```dart
@@ -389,7 +386,7 @@ void main() async {
 
 ## CORS
 
-There is a cors middleware supplied for your convenience. 
+There is a cors middleware supplied for your convenience.
 
 ```dart
 import 'package:alfred/alfred.dart';
@@ -404,3 +401,7 @@ void main() async {
   await app.listen();
 }
 ```
+
+## Logging
+
+For more details on logging [click here](documentation/logging.md).

--- a/documentation/logging.md
+++ b/documentation/logging.md
@@ -1,0 +1,77 @@
+# Logging
+
+Alfred is able to lower the log level or to integrate in a third-party
+logging solution.
+
+## Log level
+
+While developing, you can set the log level to "debug" to uncover
+more details on the request processing.
+
+```dart
+import 'dart:io';
+
+import 'package:alfred/alfred.dart';
+
+void main() async {
+  final app = Alfred(logLevel: LogType.debug);
+
+  app.get('/static/*', (req, res) => Directory('path/to/files'));
+
+  await app.listen();
+}
+```
+
+
+## Custom logging
+
+You can integrate Alfred's logging into any third party logging
+solutions or create your own.
+
+Here is an example integrating with [dart.dev logging package](https://pub.dev/packages/logging):
+
+```dart
+import 'package:alfred/alfred.dart';
+import 'package:logging/logging.dart';
+
+// Use 'logging' package instead of default logger
+
+void main() {
+  var app = Alfred();
+
+  // Configure root logger
+  Logger.root.level = Level.ALL; // defaults to Level.INFO
+  Logger.root.onRecord.listen((record) {
+    print('${record.level.name}: ${record.time}: ${record.message}');
+  });
+
+  // Create logger for Alfred app
+  var log = Logger('HttpServer');
+
+  // Create custom logWriter and map to logging package
+  app.logWriter = (messageFn, type) {
+    switch (type) {
+      case LogType.debug:
+        // avoid evaluating too much debug messages
+        if (log.level <= Level.FINE) {
+          log.fine(messageFn());
+        }
+        break;
+      case LogType.info:
+        log.info(messageFn());
+        break;
+      case LogType.warn:
+        log.warning(messageFn());
+        break;
+      case LogType.error:
+        log.severe(messageFn());
+        break;
+    }
+  };
+
+  // Configure routing...
+  app.get('/resource', (req, res) => 'response');
+
+  app.listen();
+}
+```

--- a/example/example_log_level.dart
+++ b/example/example_log_level.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+
+import 'package:alfred/alfred.dart';
+
+void main() async {
+  final app = Alfred(logLevel: LogType.debug);
+
+  app.get('/static/*', (req, res) => Directory('path/to/files'));
+
+  await app.listen();
+}

--- a/example/example_quickstart.dart
+++ b/example/example_quickstart.dart
@@ -6,6 +6,4 @@ void main() async {
   app.get('/example', (req, res) => 'Hello world');
 
   await app.listen();
-
-  print('Listening on port 3000');
 }

--- a/tool/generate_documenation.dart
+++ b/tool/generate_documenation.dart
@@ -5,9 +5,7 @@ void main() {
 
   Directory('tool/templates/documentation').listSync().forEach((file) {
     if (file.path.endsWith('.md')) {
-      var name = file.path
-          .split('/')
-          .last;
+      var name = file.path.split('/').last;
       process(file as File, File('documentation/$name'));
     }
   });
@@ -29,7 +27,7 @@ List<String> codeMacro(List<String> lines) {
       var path = line.substring(line.indexOf('@code') + '@code'.length).trim();
       var file = File(path);
       var extension =
-      file.path.substring(file.path.lastIndexOf('.') + '.'.length);
+          file.path.substring(file.path.lastIndexOf('.') + '.'.length);
       var code = file.readAsStringSync().trim().split('\n');
 
       result.add('```$extension');

--- a/tool/generate_documenation.dart
+++ b/tool/generate_documenation.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+void main() {
+  process(File('tool/templates/README.md'), File('README.md'));
+
+  Directory('tool/templates/documentation').listSync().forEach((file) {
+    if (file.path.endsWith('.md')) {
+      var name = file.path
+          .split('/')
+          .last;
+      process(file as File, File('documentation/$name'));
+    }
+  });
+}
+
+void process(File file, File to) {
+  var lines = file.readAsLinesSync();
+
+  lines = codeMacro(lines);
+
+  to.writeAsStringSync(lines.join('\n'));
+}
+
+List<String> codeMacro(List<String> lines) {
+  final result = <String>[];
+
+  for (var line in lines) {
+    if (line.trim().startsWith('@code')) {
+      var path = line.substring(line.indexOf('@code') + '@code'.length).trim();
+      var file = File(path);
+      var extension =
+      file.path.substring(file.path.lastIndexOf('.') + '.'.length);
+      var code = file.readAsStringSync().trim().split('\n');
+
+      result.add('```$extension');
+      result.addAll(code);
+      result.add('```');
+    } else {
+      result.add(line);
+    }
+  }
+
+  return result;
+}

--- a/tool/templates/README.md
+++ b/tool/templates/README.md
@@ -1,10 +1,3 @@
-import 'dart:io';
-
-String importExample(String name) =>
-    File('example/$name').readAsStringSync().trim();
-
-void main() {
-  final template = """
 # Alfred
 
 A performant, express like server framework with a few bonuses that make life even easier.
@@ -12,14 +5,13 @@ A performant, express like server framework with a few bonuses that make life ev
 [![Build Status](https://travis-ci.org/rknell/alfred.svg?branch=master)](https://travis-ci.org/rknell/alfred)
 
 Quickstart:
-```dart
-${importExample("example_quickstart.dart")}
-``` 
+
+@code example/example_quickstart.dart
 
 ## Motivation and philosophy
 
-TlDr:  
-- A minimum of dependencies, 
+TlDr:
+- A minimum of dependencies,
 - A minimum of code (199 lines at last check), and sticking close to dart core libraries
 - Ease of use
 - Predictable, well established semantics
@@ -28,8 +20,8 @@ I came to dart with a NodeJS / React Native & Cordova background. Previously I h
 my server framework, almost always calling "res.json()". I just wanted a simple framework that would
 allow me to pump out apps using dart on the server.
 
-I started with Aqueduct - It seemed like it was the most popular and better supported of the ones I 
-looked at. Aqueduct caused a bunch of errors that were nearly impossible to debug after you scratched 
+I started with Aqueduct - It seemed like it was the most popular and better supported of the ones I
+looked at. Aqueduct caused a bunch of errors that were nearly impossible to debug after you scratched
 the surface.
 
 Then I moved to Angel. Angel seemed a little less popular but concerned me because it was trying to
@@ -49,15 +41,11 @@ and run the project.
 
 if you have ever used expressjs before you should be right at home
 
-```dart
-${importExample("example.dart")}
-```
+@code example/example.dart
 
 It should do pretty much what you expect. Handling bodies though do need an "await":
 
-```dart
-${importExample("example_body_parsing.dart")}
-```
+@code example/example_body_parsing.dart
 
 Internally dart provides a body parser, so no extra dependencies there.
 
@@ -74,18 +62,14 @@ Each route accepts a Future as response. Currently you can pass back the followi
 
 If you want to return HTML, just set the content type to HTML like this:
 
-```dart
-${importExample("example_html.dart")}
-```
+@code example/example_html.dart
 
 ### Custom type handlers
 If you want to create custom type handlers, just add them to the type handler
 array in the app object. This is a bit advanced, and I expect it would be more
 for devs wanting to extend Alfred:
 
-```dart
-${importExample("example_custom_type_handler.dart")}
-```
+@code example/example_custom_type_handler.dart
 
 ## File downloads
 
@@ -96,9 +80,7 @@ You can just set the right headers, but there is a handy little helper that will
 
 See `res.setDownload` below.
 
-```dart
-${importExample("example_file_downloads.dart")}
-```
+@code example/example_file_downloads.dart
 
 ## But what about Mongo or Postgres or <Databse x>?
 
@@ -128,24 +110,20 @@ provides over the core library is the routing and route param extraction.
 
 ## Routing
 
-Routing follows a similar pattern to the more basic ExpressJS routes. While there is some regex 
+Routing follows a similar pattern to the more basic ExpressJS routes. While there is some regex
 matching, mostly just stick with the route name and param syntax from Express:
 
 "/path/to/:id/property" etc
 
 So for example:
 
-```dart
-${importExample("example_routing.dart")}
-```
+@code example/example_routing.dart
 
 You can also use a wildcard for a route, and provided another route hasn't already resolved the
 response it will be hit. So for example if you want to authenticate a whole section of an api you
 can do this:
 
-```dart
-${importExample("example_middleware_authentication_wildcard.dart")}
-```
+@code example/example_middleware_authentication_wildcard.dart
 
 ## Middleware
 
@@ -153,17 +131,13 @@ At present the middleware system probably isn't built out enough, but will do fo
 
 Right now you can specify a middleware for all routes by declaring:
 
-```dart
-${importExample("example_middleware_2.dart")}
-```
+@code example/example_middleware_2.dart
 
 Middleware declared this way will be executed in the order its added to the app.
 
 You can also add middleware to a route like so:
 
-```dart
-${importExample("example_middleware.dart")}
-```
+@code example/example_middleware.dart
 
 ### What? No 'next'? how do I even?
 
@@ -177,48 +151,37 @@ If you return null it will yield to the next middleware or route.
 
 ## Error handling
 
-You can either set the status code on the response object yourself and send the data manually, or 
+You can either set the status code on the response object yourself and send the data manually, or
 you can do this from any route:
 
-```dart
 app.get("/",(req, res) => throw AlfredException(400, {"message": "invalid request"}));
-```
 
 If any of the routes bubble an unhandled error, it will catch it and throw a 500 error.
 
-If you want to handle the logic when a 500 error is thrown, you can add a custom handler when you 
+If you want to handle the logic when a 500 error is thrown, you can add a custom handler when you
 instantiate the app. For example:
 
-```dart
-${importExample("example_error_handling.dart")}
-```
+@code example/example_error_handling.dart
 
 ### 404 Handling
 
 404 Handling works the same as 500 error handling (or uncaught error handling). There is a default
 behaviour, but if you want to override it, simply handle it in the app declaration.
 
-```dart
-${importExample("example_missing_handler.dart")}
-```
+@code example/example_missing_handler.dart
 ## Static Files
 
 This one is super easy - just pass in a public path and a dart Directory object and Alfred does
 the rest.
 
-```dart
-${importExample("example_static_files.dart")}
-```
+@code example/example_static_files.dart
 
 ## CORS
 
-There is a cors middleware supplied for your convenience. 
+There is a cors middleware supplied for your convenience.
 
-```dart
-${importExample("example_cors.dart")}
-```
+@code example/example_cors.dart
 
-  """;
+## Logging
 
-  File('README.md').writeAsStringSync(template.trim());
-}
+For more details on logging [click here](documentation/logging.md).

--- a/tool/templates/documentation/logging.md
+++ b/tool/templates/documentation/logging.md
@@ -1,0 +1,21 @@
+# Logging
+
+Alfred is able to lower the log level or to integrate in a third-party
+logging solution.
+
+## Log level
+
+While developing, you can set the log level to "debug" to uncover
+more details on the request processing.
+
+@code example/example_log_level.dart
+
+
+## Custom logging
+
+You can integrate Alfred's logging into any third party logging
+solutions or create your own.
+
+Here is an example integrating with [dart.dev logging package](https://pub.dev/packages/logging):
+
+@code example/example_custom_logging.dart


### PR DESCRIPTION
Evolved @rknell 's approach on including dart files into readme.

All documentation is now located at `tool/templates`.

I don't think we can put all the documentation into the `README.md`. Therefore I created a directory `documentation` that may contain multiple markdown files with deeper explanation and examples. I created an example md file about logging for proof of concept. We can improve on that later.

The documentation now is written in pure md file, which allows us to use markdown viewer tooling.

I added macro support, that's resolved by the code generator (`tool/generate_documentation.dart`). The first macro is `@code`. Example:

```md
This is some markdown file explaining something.

See example:

@code example/name_of_example.dart
```

I also added an example link from `README.md` to `documentation/logging.md` to demonstrate the pattern.