### PR TITLE
improve directory type handler

### DIFF
--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -220,6 +220,10 @@ class Alfred {
   /// Handles and routes an incoming request
   ///
   Future<void> _incomingRequest(HttpRequest request) async {
+    /// Expose this Alfred instance for middleware or other utility functions
+    request.store.set('_internal_alfred', this);
+
+    /// Variable to track the close of the response
     var isDone = false;
 
     logWriter(

--- a/lib/src/extensions/request_helpers.dart
+++ b/lib/src/extensions/request_helpers.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:http_server/http_server.dart';
 
+import '../../alfred.dart';
 import '../plugins/store_plugin.dart';
 import '../route_matcher.dart';
 
@@ -25,4 +26,8 @@ extension RequestHelpers on HttpRequest {
   /// Get the matched route of the current request
   ///
   String get route => store.get<String?>('_internal_route') ?? '';
+
+  /// Get Alfred instance which is associated with this request
+  ///
+  Alfred get alfred => store.get<Alfred>('_internal_alfred');
 }

--- a/lib/src/type_handlers/directory_type_handler.dart
+++ b/lib/src/type_handlers/directory_type_handler.dart
@@ -43,7 +43,6 @@ Future _respondWithFile(HttpResponse res, File file) async {
   await res.close();
 }
 
-
 extension _Logger on HttpRequest {
   void log(String Function() msgFn) =>
       alfred.logWriter(() => 'DirectoryTypeHandler: ${msgFn()}', LogType.debug);

--- a/lib/src/type_handlers/directory_type_handler.dart
+++ b/lib/src/type_handlers/directory_type_handler.dart
@@ -1,24 +1,39 @@
 import 'dart:io';
+import 'dart:math';
+
+import 'package:alfred/alfred.dart';
 
 import '../extensions/request_helpers.dart';
 import '../extensions/response_helpers.dart';
 import 'type_handler.dart';
 
 TypeHandler get directoryTypeHandler =>
-    TypeHandler<Directory>((req, res, dynamic val) async {
-      final filePath =
-          "${val.path}/${req.uri.path.replaceFirst(req.route.replaceAll("*", ""), "")}";
+    TypeHandler<Directory>((req, res, dynamic directory) async {
+      directory = directory as Directory;
+      var usedRoute = req.route;
+
+      assert(usedRoute.endsWith('*'),
+          'TypeHandler of type Directory needs a route declaration that ends with a wildcard (*). Found: $usedRoute');
+
+      final virtualPath = req.uri.path
+          .substring(min(req.uri.path.length, usedRoute.indexOf('*')));
+      final filePath = '${directory.path}/$virtualPath';
+
+      req.log(() => 'Resolve virtual path: $virtualPath');
+
       final fileCandidates = <File>[
         File(filePath),
         File('$filePath/index.html'),
         File('$filePath/index.htm'),
       ];
 
-      for (final file in fileCandidates) {
-        if (file.existsSync()) {
-          await _respondWithFile(res, file);
-          break;
-        }
+      try {
+        var match = fileCandidates.firstWhere((file) => file.existsSync());
+        req.log(() => 'Respond with file: ${match.path}');
+        await _respondWithFile(res, match);
+      } on StateError {
+        req.log(
+            () => 'Could not match with any file. Expected file at: $filePath');
       }
     });
 
@@ -26,4 +41,9 @@ Future _respondWithFile(HttpResponse res, File file) async {
   res.setContentTypeFromFile(file);
   await res.addStream(file.openRead());
   await res.close();
+}
+
+extension _Logger on HttpRequest {
+  void log(String Function() msgFn) =>
+      alfred.logWriter(() => 'DirectoryTypeHandler: ${msgFn()}', LogType.debug);
 }

--- a/lib/src/type_handlers/directory_type_handler.dart
+++ b/lib/src/type_handlers/directory_type_handler.dart
@@ -43,6 +43,7 @@ Future _respondWithFile(HttpResponse res, File file) async {
   await res.close();
 }
 
+
 extension _Logger on HttpRequest {
   void log(String Function() msgFn) =>
       alfred.logWriter(() => 'DirectoryTypeHandler: ${msgFn()}', LogType.debug);

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -272,6 +272,15 @@ void main() {
     expect(response.headers['content-type'], 'application/pdf');
   });
 
+  test('it serves static files although directories do not match', () async {
+    app.get('/my/directory/*', (req, res) => Directory('test/files'));
+
+    final response = await http
+        .get(Uri.parse('http://localhost:$port/my/directory/dummy.pdf'));
+    expect(response.statusCode, 200);
+    expect(response.headers['content-type'], 'application/pdf');
+  });
+
   test('it serves SPA projects', () async {
     app.get('/spa/*', (req, res) => Directory('test/files/spa'));
     app.get('/spa/*', (req, res) => File('test/files/spa/index.html'));


### PR DESCRIPTION
Improve the logic of the Directory TypeHandler.

In previous implementation both paths required to match:
```dart
app.get('/must/match/to/*', (req, res) => Directory('must/match/to')); // works
app.get('/virtual/path/*', (req, res) => Directory('physical/directory')); // fails
```

This implementation solves that by computing the virtual path (all after the `*` is the virtual path), and adds it to the specified directory root.

This change also "exposes" the Alfred instance for any extension to access logging.