### PR TITLE
fix 404 handling

### DIFF
--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -248,20 +248,11 @@ class Alfred {
       // continue and process the routes
       if (effectiveRoutes.isEmpty) {
         logWriter(() => 'No matching route found.', LogType.debug);
-        if (onNotFound != null) {
-          // Otherwise check if a custom 404 handler has been provided
-          final dynamic result = await onNotFound!(request, request.response);
-          if (result != null && !isDone) {
-            await _handleResponse(result, request);
-          }
-          await request.response.close();
-        } else {
-          // Otherwise throw a generic 404;
-          request.response.statusCode = 404;
-          request.response.write('404 not found');
-          await request.response.close();
-        }
+        await _respondNotFound(request, isDone);
       } else {
+        /// Tracks if one route is using a wildcard
+        var nonWildcardRouteMatch = false;
+
         // Loop through the routes in the order they are in the routes list
         for (var route in effectiveRoutes) {
           if (isDone) {
@@ -269,6 +260,8 @@ class Alfred {
           }
           logWriter(() => 'Match route: ${route.route}', LogType.debug);
           request.store.set('_internal_route', route.route);
+          nonWildcardRouteMatch =
+              !route.usesWildcardMatcher || nonWildcardRouteMatch;
 
           /// Loop through any middleware
           for (var middleware in route.middleware) {
@@ -299,10 +292,14 @@ class Alfred {
         ///
         if (!isDone) {
           if (request.response.contentLength == -1) {
-            logWriter(
-                () => 'Warning: Returning a response with no content. '
-                    '${effectiveRoutes.map((e) => e.route).join(', ')}',
-                LogType.warn);
+            if (nonWildcardRouteMatch) {
+              logWriter(
+                  () => 'Warning: Returning a response with no content. '
+                      '${effectiveRoutes.map((e) => e.route).join(', ')}',
+                  LogType.warn);
+            } else {
+              await _respondNotFound(request, isDone);
+            }
           }
           await request.response.close();
         }
@@ -311,6 +308,8 @@ class Alfred {
       // The user threw a handle HTTP Exception
       request.response.statusCode = e.statusCode;
       await _handleResponse(e.response, request);
+    } on NotFoundError catch (_) {
+      await _respondNotFound(request, isDone);
     } catch (e, s) {
       // Its all broken, bail (but don't crash)
       logWriter(() => e, LogType.error);
@@ -331,6 +330,24 @@ class Alfred {
           await request.response.close();
         } catch (_) {}
       }
+    }
+  }
+
+  /// Responds request with a NotFound response
+  ///
+  Future _respondNotFound(HttpRequest request, bool isDone) async {
+    if (onNotFound != null) {
+      // Otherwise check if a custom 404 handler has been provided
+      final dynamic result = await onNotFound!(request, request.response);
+      if (result != null && !isDone) {
+        await _handleResponse(result, request);
+      }
+      await request.response.close();
+    } else {
+      // Otherwise throw a generic 404;
+      request.response.statusCode = 404;
+      request.response.write('404 not found');
+      await request.response.close();
     }
   }
 
@@ -376,3 +393,7 @@ class NoTypeHandlerError extends Error {
   String toString() =>
       'No type handler found for ${object.runtimeType} / ${object.toString()} \nRoute: ${request.route}\nIf the app is running in production mode, the type name may be minified. Run it in debug mode to resolve';
 }
+
+/// Error used by middleware, utils or type handler to elevate
+/// a NotFound response.
+class NotFoundError extends Error {}

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -12,4 +12,8 @@ class HttpRoute {
 
   HttpRoute(this.route, this.callback, this.method,
       {this.middleware = const []});
+
+  /// Returns `true` if route can match multiple routes due to usage of
+  /// wildcards (`*`)
+  bool get usesWildcardMatcher => route.contains('*');
 }

--- a/lib/src/type_handlers/file_type_handler.dart
+++ b/lib/src/type_handlers/file_type_handler.dart
@@ -1,14 +1,17 @@
 import 'dart:io';
 
+import '../alfred.dart';
 import '../extensions/response_helpers.dart';
 import 'type_handler.dart';
 
 TypeHandler get fileTypeHandler =>
-    TypeHandler<File>((HttpRequest req, HttpResponse res, dynamic val) async {
-      val = val as File;
-      if (val.existsSync()) {
-        res.setContentTypeFromFile(val);
-        await res.addStream(val.openRead());
+    TypeHandler<File>((HttpRequest req, HttpResponse res, dynamic file) async {
+      file = file as File;
+      if (file.existsSync()) {
+        res.setContentTypeFromFile(file);
+        await res.addStream(file.openRead());
         return res.close();
+      } else {
+        throw NotFoundError();
       }
     });

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -122,7 +122,8 @@ void main() {
   test('not found with directory type handler', () async {
     app.get('/files/*', (req, res) => Directory('test/files'));
 
-    final r = await http.get(Uri.parse('http://localhost:$port/files/no-file.zip'));
+    final r =
+        await http.get(Uri.parse('http://localhost:$port/files/no-file.zip'));
     expect(r.body, '404 not found');
     expect(r.statusCode, 404);
   });

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -122,7 +122,7 @@ void main() {
   test('not found with directory type handler', () async {
     app.get('/files/*', (req, res) => Directory('test/files'));
 
-    final r = await http.get(Uri.parse('http://localhost:$port/no-file.zip'));
+    final r = await http.get(Uri.parse('http://localhost:$port/files/no-file.zip'));
     expect(r.body, '404 not found');
     expect(r.statusCode, 404);
   });

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -375,7 +375,7 @@ void main() {
   });
 
   test('it should log out request information', () async {
-    app.get('/resource', (req, res) => 'r', middleware: [cors()]);
+    app.get('/resource', (req, res) => 'response', middleware: [cors()]);
     var logs = <String>[];
     app.logWriter = (msgFn, type) => logs.add('$type ${msgFn()}');
     await http.get(Uri.parse('http://localhost:$port/resource'));


### PR DESCRIPTION
Fixes issue https://github.com/rknell/alfred/issues/22.

If `effectiveRoutes` were generated but no content was produced, it checks if there was any route, that doesn't matches on wildcards. If so, it also evaluates 404 handler.

Also introduced `NotFoundError` which can be thrown by middleware or typehandler. Alfred catches this error type and uses the configured `onNotFound` handler to respond. I used for the `File` type handler.