### PR TITLE
rewritten route matcher

### DIFF
--- a/lib/src/type_handlers/directory_type_handler.dart
+++ b/lib/src/type_handlers/directory_type_handler.dart
@@ -12,8 +12,8 @@ TypeHandler get directoryTypeHandler =>
       directory = directory as Directory;
       var usedRoute = req.route;
 
-      assert(usedRoute.endsWith('*'),
-          'TypeHandler of type Directory needs a route declaration that ends with a wildcard (*). Found: $usedRoute');
+      assert(usedRoute.contains('*'),
+          'TypeHandler of type Directory needs a route declaration that contains a wildcard (*). Found: $usedRoute');
 
       final virtualPath = req.uri.path
           .substring(min(req.uri.path.length, usedRoute.indexOf('*')));

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -315,6 +315,19 @@ void main() {
     expect(response.headers['content-type'], 'application/pdf');
   });
 
+  test('it serves static files with basic filtering', () async {
+    app.get('/my/directory/*.pdf', (req, res) => Directory('test/files'));
+
+    final r1 = await http
+        .get(Uri.parse('http://localhost:$port/my/directory/dummy.pdf'));
+    expect(r1.statusCode, 200);
+    expect(r1.headers['content-type'], 'application/pdf');
+
+    final r2 = await http
+        .get(Uri.parse('http://localhost:$port/my/directory/image.jpg'));
+    expect(r2.statusCode, 404);
+  });
+
   test('it serves SPA projects', () async {
     app.get('/spa/*', (req, res) => Directory('test/files/spa'));
     app.get('/spa/*', (req, res) => File('test/files/spa/index.html'));

--- a/test/route_matcher_test.dart
+++ b/test/route_matcher_test.dart
@@ -147,6 +147,7 @@ void main() {
     final testRoutes = [
       HttpRoute('[a-z]+/[0-9]+', _callback, Method.get),
       HttpRoute('[a-z]{5}', _callback, Method.get),
+      HttpRoute('(a|b)/c', _callback, Method.get),
     ];
 
     expect(match('a/b', testRoutes), <String>[]);
@@ -157,6 +158,8 @@ void main() {
     expect(match('abc42', testRoutes), <String>[]);
     expect(match('abcde', testRoutes), <String>['[a-z]{5}']);
     expect(match('final', testRoutes), <String>['[a-z]{5}']);
+    expect(match('a/c', testRoutes), <String>['(a|b)/c']);
+    expect(match('b/c', testRoutes), <String>['(a|b)/c']);
   });
 }
 

--- a/test/route_matcher_test.dart
+++ b/test/route_matcher_test.dart
@@ -5,95 +5,53 @@ import 'package:test/test.dart';
 void main() {
   test('it should match routes correctly', () {
     final testRoutes = [
-      HttpRoute('/a/:id/go', (req, res) async {}, Method.get),
-      HttpRoute('/a', (req, res) async {}, Method.get),
-      HttpRoute('/b/a/:input/another', (req, res) async {}, Method.get),
-      HttpRoute('/b/a/:input', (req, res) async {}, Method.get),
-      HttpRoute('/b/B/:input', (req, res) async {}, Method.get),
-      HttpRoute('/[a-z]/yep', (req, res) async {}, Method.get),
+      HttpRoute('/a/:id/go', _callback, Method.get),
+      HttpRoute('/a', _callback, Method.get),
+      HttpRoute('/b/a/:input/another', _callback, Method.get),
+      HttpRoute('/b/a/:input', _callback, Method.get),
+      HttpRoute('/b/B/:input', _callback, Method.get),
+      HttpRoute('/[a-z]/yep', _callback, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/a', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/a']);
-    expect(
-        RouteMatcher.match('/a?query=true', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/a']);
-    expect(
-        RouteMatcher.match('/a/123/go', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/a/:id/go']);
-    expect(
-        RouteMatcher.match('/a/123/go/a', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        <String>[]);
-    expect(
-        RouteMatcher.match('/b/a/adskfjasjklf/another', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
+    expect(match('/a', testRoutes), ['/a']);
+    expect(match('/a?query=true', testRoutes), ['/a']);
+    expect(match('/a/123/go', testRoutes), ['/a/:id/go']);
+    expect(match('/a/123/go/a', testRoutes), <String>[]);
+    expect(match('/b/a/adskfjasjklf/another', testRoutes),
         ['/b/a/:input/another']);
-    expect(
-        RouteMatcher.match('/b/a/adskfjasj', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/b/a/:input']);
-    expect(
-        RouteMatcher.match('/d/yep', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/[a-z]/yep']);
-    expect(
-        RouteMatcher.match('/b/B/yep', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/b/B/:input']);
+    expect(match('/b/a/adskfjasj', testRoutes), ['/b/a/:input']);
+    expect(match('/d/yep', testRoutes), ['/[a-z]/yep']);
+    expect(match('/b/B/yep', testRoutes), ['/b/B/:input']);
   });
 
   test('it should match wildcards', () {
     final testRoutes = [
-      HttpRoute('*', (req, res) async {}, Method.get),
-      HttpRoute('/a', (req, res) async {}, Method.get),
-      HttpRoute('/b', (req, res) async {}, Method.get),
+      HttpRoute('*', _callback, Method.get),
+      HttpRoute('/a', _callback, Method.get),
+      HttpRoute('/b', _callback, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/a', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['*', '/a']);
+    expect(match('/a', testRoutes), ['*', '/a']);
   });
 
   test('it should generously match wildcards for sub-paths', () {
     final testRoutes = [
-      HttpRoute('path/*', (req, res) async {}, Method.get),
+      HttpRoute('path/*', _callback, Method.get),
     ];
 
-    expect(RouteMatcher.match('/path/to', testRoutes, Method.get).isNotEmpty,
-        true);
-    expect(
-        RouteMatcher.match('/path/', testRoutes, Method.get).isNotEmpty, true);
-    expect(
-        RouteMatcher.match('/path', testRoutes, Method.get).isNotEmpty, true);
+    expect(match('/path/to', testRoutes), ['path/*']);
+    expect(match('/path/', testRoutes), ['path/*']);
+    expect(match('/path', testRoutes), ['path/*']);
   });
 
-  test('it should respect the routemethod', () {
+  test('it should respect the route method', () {
     final testRoutes = [
-      HttpRoute('*', (req, res) async {}, Method.post),
-      HttpRoute('/a', (req, res) async {}, Method.get),
-      HttpRoute('/b', (req, res) async {}, Method.get),
+      HttpRoute('*', _callback, Method.post),
+      HttpRoute('/a', _callback, Method.get),
+      HttpRoute('/b', _callback, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/a', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/a']);
+    expect(match('/a', testRoutes), ['/a']);
   });
 
   test('it should extract the route params correctly', () {
@@ -105,8 +63,8 @@ void main() {
 
   test('it should correctly match routes that have a partial match', () {
     final testRoutes = [
-      HttpRoute('/image', (req, res) async {}, Method.get),
-      HttpRoute('/imageSource', (req, res) async {}, Method.get)
+      HttpRoute('/image', _callback, Method.get),
+      HttpRoute('/imageSource', _callback, Method.get)
     ];
 
     expect(
@@ -129,58 +87,80 @@ void main() {
 
   test('it should ignore a trailing slash', () {
     final testRoutes = [
-      HttpRoute('/b/', (req, res) async {}, Method.get),
+      HttpRoute('/b/', _callback, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/b?qs=true', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/b/']);
+    expect(match('/b?qs=true', testRoutes), ['/b/']);
   });
 
   test('it should ignore a trailing slash in reverse', () {
     final testRoutes = [
-      HttpRoute('/b', (req, res) async {}, Method.get),
+      HttpRoute('/b', _callback, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/b/?qs=true', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/b']);
+    expect(match('/b/?qs=true', testRoutes), ['/b']);
   });
 
   test('it should hit a wildcard route halfway through the uri', () {
     final testRoutes = [
-      HttpRoute('/route/*', (req, res) async {}, Method.get),
-      HttpRoute('/route/route2', (req, res) async {}, Method.get),
+      HttpRoute('/route/*', _callback, Method.get),
+      HttpRoute('/route/route2', _callback, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/route/route2', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/route/*', '/route/route2']);
+    expect(match('/route/route2', testRoutes), ['/route/*', '/route/route2']);
   });
 
   test('it should hit a wildcard route halfway through the uri - sibling', () {
     final testRoutes = [
-      HttpRoute('/route*', (req, res) async {}, Method.get),
-      HttpRoute('/route', (req, res) async {}, Method.get),
-      HttpRoute('/route/test', (req, res) async {}, Method.get),
+      HttpRoute('/route*', _callback, Method.get),
+      HttpRoute('/route', _callback, Method.get),
+      HttpRoute('/route/test', _callback, Method.get),
     ];
 
-    expect(
-        RouteMatcher.match('/route', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/route*', '/route']);
+    expect(match('/route', testRoutes), ['/route*', '/route']);
 
-    expect(
-        RouteMatcher.match('/route/test', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
-        ['/route*', '/route/test']);
+    expect(match('/route/test', testRoutes), ['/route*', '/route/test']);
+  });
+
+  test('it should match wildcards in the middle', () {
+    final testRoutes = [
+      HttpRoute('/a/*/b', _callback, Method.get),
+      HttpRoute('/a/*/*/b', _callback, Method.get),
+    ];
+
+    expect(match('/a', testRoutes), <String>[]);
+    expect(match('/a/x/b', testRoutes), ['/a/*/b']);
+    expect(match('/a/x/y/b', testRoutes), ['/a/*/b', '/a/*/*/b']);
+  });
+
+  test('it should match wildcards at the beginning', () {
+    final testRoutes = [
+      HttpRoute('*.jpg', _callback, Method.get),
+    ];
+
+    expect(match('xjpg', testRoutes), <String>[]);
+    expect(match('.jpg', testRoutes), <String>['*.jpg']);
+    expect(match('path/to/picture.jpg', testRoutes), <String>['*.jpg']);
+  });
+
+  test('it should match regex expressions within segments', () {
+    final testRoutes = [
+      HttpRoute('[a-z]+/[0-9]+', _callback, Method.get),
+      HttpRoute('[a-z]{5}', _callback, Method.get),
+    ];
+
+    expect(match('a/b', testRoutes), <String>[]);
+    expect(match('3/a', testRoutes), <String>[]);
+    expect(match('x/323', testRoutes), <String>['[a-z]+/[0-9]+']);
+    expect(match('answer/42', testRoutes), <String>['[a-z]+/[0-9]+']);
+    expect(match('abc', testRoutes), <String>[]);
+    expect(match('abc42', testRoutes), <String>[]);
+    expect(match('abcde', testRoutes), <String>['[a-z]{5}']);
+    expect(match('final', testRoutes), <String>['[a-z]{5}']);
   });
 }
+
+List<String> match(String input, List<HttpRoute> routes) =>
+    RouteMatcher.match(input, routes, Method.get).map((e) => e.route).toList();
+
+Future Function(HttpRequest, HttpResponse) get _callback => (req, res) async {};


### PR DESCRIPTION
I've rewritten the HTTP matcher because I perceived some strange results when using whitecards.

It now translates the whole route string into a single regular expression. It's also less complex. The algorithm is pretty straightforward.

Additionally it allows some more cool route expression:

```dart
app.get('*.(jpg|jpeg)', (req, res) {
  // insert jpeg specific middleware here...
});

// can resolve http://localhost:3000/download/files/image.jpg
app.get('/download/*.jpg', (req, res) => Directory('test'));

// can resolve http://localhost:3000/a/b/c/d/e/f
app.get('a/*/f', (req, res) => 'response');
```