### PR TITLE
Avoid parsing / String manipulations in RouteMatcher + improve type safety in TypeHandlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,8 +418,8 @@ class Chicken {
 void main() {
   final app = Alfred();
 
-  app.typeHandlers.add(TypeHandler<Chicken>((req, res, dynamic val) async {
-    res.write((val as Chicken).response);
+  app.typeHandlers.add(TypeHandler<Chicken>((req, res, Chicken val) async {
+    res.write(val.response);
     await res.close();
   }));
 

--- a/example/example_custom_type_handler.dart
+++ b/example/example_custom_type_handler.dart
@@ -7,8 +7,8 @@ class Chicken {
 void main() {
   final app = Alfred();
 
-  app.typeHandlers.add(TypeHandler<Chicken>((req, res, dynamic val) async {
-    res.write((val as Chicken).response);
+  app.typeHandlers.add(TypeHandler<Chicken>((req, res, Chicken val) async {
+    res.write(val.response);
     await res.close();
   }));
 

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -290,6 +290,7 @@ class Alfred {
             break;
           }
           logWriter(() => 'Match route: ${route.route}', LogType.debug);
+          request.store.unset('_internal_params');
           request.store.set('_internal_route', route.route);
           nonWildcardRouteMatch =
               !route.usesWildcardMatcher || nonWildcardRouteMatch;

--- a/lib/src/extensions/request_helpers.dart
+++ b/lib/src/extensions/request_helpers.dart
@@ -30,11 +30,13 @@ extension RequestHelpers on HttpRequest {
 
   /// Get params
   ///
-  Map<String, String> get params => RouteMatcher.getParams(route, uri.path);
+  Map<String, String> get params =>
+      store.getOrSet<Map<String, String>>('_internal_params',
+        () => RouteMatcher.getParams(route, uri.path));
 
   /// Get the matched route of the current request
   ///
-  String get route => store.get<String?>('_internal_route') ?? '';
+  String get route => store.tryGet<String>('_internal_route') ?? '';
 
   /// Get Alfred instance which is associated with this request
   ///

--- a/lib/src/extensions/string_helpers.dart
+++ b/lib/src/extensions/string_helpers.dart
@@ -1,0 +1,12 @@
+extension PathNormalizer on String {
+  /// Trims all slashes at the start and end
+  String get normalizePath {
+    if (startsWith('/')) {
+      return substring('/'.length).normalizePath;
+    }
+    if (endsWith('/')) {
+      return substring(0, length - '/'.length).normalizePath;
+    }
+    return this;
+  }
+}

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -10,10 +10,59 @@ class HttpRoute {
   final Method method;
   final List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware;
 
+  final RegExp matcher;
+  final List<String> parts;
+
   HttpRoute(this.route, this.callback, this.method,
-      {this.middleware = const []});
+      {this.middleware = const []}) : matcher = _buildMatcher(route), parts = route.split('/')..remove('');
 
   /// Returns `true` if route can match multiple routes due to usage of
   /// wildcards (`*`)
   bool get usesWildcardMatcher => route.contains('*');
+
+  static RegExp _buildMatcher(String route) {
+    /// Split route path into segments
+    final segments = Uri.parse(route.normalizePath).pathSegments;
+
+    var matcher = '^';
+    for (var segment in segments) {
+      if (segment == '*' &&
+          segment != segments.first &&
+          segment == segments.last) {
+        /// Generously match path if last segment is wildcard (*)
+        /// Example: 'some/path/*' => should match 'some/path'
+        matcher += '/?.*';
+      } else if (segment != segments.first) {
+        /// Add path separators
+        matcher += '/';
+      }
+
+      /// escape period character
+      segment = segment.replaceAll('.', r'\.');
+
+      /// parameter (':something') to anything but slash
+      segment = segment.replaceAll(RegExp(':.+'), '[^/]+?');
+
+      /// wildcard ('*') to anything
+      segment = segment.replaceAll('*', '.*?');
+
+      matcher += segment;
+    }
+    matcher += r'$';
+
+    return RegExp(matcher, caseSensitive: false);
+  }
+}
+
+extension _PathNormalizer on String {
+  /// Trims all slashes at the start and end
+  String get normalizePath {
+    if (startsWith('/')) {
+      return substring('/'.length).normalizePath;
+    }
+    if (endsWith('/')) {
+      return substring(0, length - '/'.length).normalizePath;
+    }
+    return this;
+  }
 }

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import '../alfred.dart';
+import 'extensions/string_helpers.dart';
 import 'alfred.dart';
 
 class HttpRoute {
@@ -11,14 +12,13 @@ class HttpRoute {
   final List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware;
 
   final RegExp matcher;
-  final List<String> parts;
-
-  HttpRoute(this.route, this.callback, this.method,
-      {this.middleware = const []}) : matcher = _buildMatcher(route), parts = route.split('/')..remove('');
 
   /// Returns `true` if route can match multiple routes due to usage of
   /// wildcards (`*`)
-  bool get usesWildcardMatcher => route.contains('*');
+  final bool usesWildcardMatcher;
+
+  HttpRoute(this.route, this.callback, this.method, {this.middleware = const []})
+    : matcher = _buildMatcher(route), usesWildcardMatcher = route.contains('*');
 
   static RegExp _buildMatcher(String route) {
     /// Split route path into segments
@@ -32,6 +32,7 @@ class HttpRoute {
         /// Generously match path if last segment is wildcard (*)
         /// Example: 'some/path/*' => should match 'some/path'
         matcher += '/?.*';
+        break;
       } else if (segment != segments.first) {
         /// Add path separators
         matcher += '/';
@@ -51,18 +52,5 @@ class HttpRoute {
     matcher += r'$';
 
     return RegExp(matcher, caseSensitive: false);
-  }
-}
-
-extension _PathNormalizer on String {
-  /// Trims all slashes at the start and end
-  String get normalizePath {
-    if (startsWith('/')) {
-      return substring('/'.length).normalizePath;
-    }
-    if (endsWith('/')) {
-      return substring(0, length - '/'.length).normalizePath;
-    }
-    return this;
   }
 }

--- a/lib/src/plugins/store_plugin.dart
+++ b/lib/src/plugins/store_plugin.dart
@@ -29,12 +29,48 @@ class RequestStore {
   ///
   /// Example:
   /// ```dart
+  /// var foo = req.store.tryGet<Foo>('foo');
+  /// ```
+  T? tryGet<T>(String key) {
+    dynamic data = _data[key];
+    assert(data == null || data is T, 'Store value for key $key does not match type $T');
+    return data as T?;
+  }
+
+  /// Returns the stored value that has been associated with the specified [key].
+  /// Will throw if null or no value was registered.
+  ///
+  /// Example:
+  /// ```dart
   /// var foo = req.store.get<Foo>('foo');
   /// ```
   T get<T>(String key) {
-    assert(_data[key] is T, 'Store value for key $key does not match type $T');
-    return _data[key] as T;
+    return tryGet<T>(key) as T;
   }
+
+  /// Gets the value for the specified [key] or sets it using the [builder].
+  ///
+  /// Example:
+  /// ```dart
+  /// var foo = req.store.getOrSet<ExpensiveFoo>('foo', () => ExpensiveFoo());
+  /// ```
+  T getOrSet<T>(String key, T Function() builder) {
+    if (!_data.containsKey(key)) {
+      final value = builder();
+      set(key, value);
+      return value;
+    } else {
+      return get<T>(key);
+    }
+  }
+
+  /// Clear any value associated with the specified [key].
+  ///
+  /// Example:
+  /// ```dart
+  /// req.store.unset('foo');
+  /// ```
+  void unset(String key) => _data.remove(key);
 }
 
 /// Used within [Alfred] to remove request-related data after

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -1,4 +1,5 @@
 import '../alfred.dart';
+import 'extensions/string_helpers.dart';
 import 'alfred.dart';
 import 'http_route.dart';
 
@@ -15,36 +16,7 @@ class RouteMatcher {
         continue;
       }
 
-      /// Split route path into segments
-      final segments = Uri.parse(option.route.normalizePath).pathSegments;
-
-      var matcher = '^';
-      for (var segment in segments) {
-        if (segment == '*' &&
-            segment != segments.first &&
-            segment == segments.last) {
-          /// Generously match path if last segment is wildcard (*)
-          /// Example: 'some/path/*' => should match 'some/path'
-          matcher += '/?.*';
-        } else if (segment != segments.first) {
-          /// Add path separators
-          matcher += '/';
-        }
-
-        /// escape period character
-        segment = segment.replaceAll('.', r'\.');
-
-        /// parameter (':something') to anything but slash
-        segment = segment.replaceAll(RegExp(':.+'), '[^/]+?');
-
-        /// wildcard ('*') to anything
-        segment = segment.replaceAll('*', '.*?');
-
-        matcher += segment;
-      }
-      matcher += r'$';
-
-      if (RegExp(matcher, caseSensitive: false).hasMatch(inputPath)) {
+      if (option.matcher.hasMatch(inputPath)) {
         output.add(option);
       }
     }
@@ -75,19 +47,6 @@ class RouteMatcher {
       }
     }
     return output;
-  }
-}
-
-extension _PathNormalizer on String {
-  /// Trims all slashes at the start and end
-  String get normalizePath {
-    if (startsWith('/')) {
-      return substring('/'.length).normalizePath;
-    }
-    if (endsWith('/')) {
-      return substring(0, length - '/'.length).normalizePath;
-    }
-    return this;
   }
 }
 

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -4,10 +4,8 @@ import 'alfred.dart';
 import 'http_route.dart';
 
 class RouteMatcher {
-  static List<HttpRoute> match(
-      String input, List<HttpRoute> options, Method method) {
-    final output = <HttpRoute>[];
-
+  static Iterable<HttpRoute> match(
+      String input, List<HttpRoute> options, Method method) sync* {
     final inputPath = Uri.parse(input).path.normalizePath;
 
     for (final option in options) {
@@ -17,11 +15,9 @@ class RouteMatcher {
       }
 
       if (option.matcher.hasMatch(inputPath)) {
-        output.add(option);
+        yield option;
       }
     }
-
-    return output;
   }
 
   static Map<String, String> getParams(String route, String input) {

--- a/lib/src/type_handlers/binary_type_handlers.dart
+++ b/lib/src/type_handlers/binary_type_handlers.dart
@@ -5,12 +5,12 @@ import 'dart:typed_data';
 import 'package:alfred/src/type_handlers/type_handler.dart';
 
 FutureOr _binaryTypeHandler(
-    HttpRequest req, HttpResponse res, dynamic val) async {
+    HttpRequest req, HttpResponse res, List<int> val) async {
   if (res.headers.contentType == null ||
       res.headers.contentType!.value == 'text/plain') {
     res.headers.contentType = ContentType.binary;
   }
-  res.add(val as List<int>);
+  res.add(val);
   await res.close();
 }
 
@@ -21,11 +21,11 @@ TypeHandler get uint8listTypeHandler =>
     TypeHandler<Uint8List>(_binaryTypeHandler);
 
 TypeHandler get binaryStreamTypeHandler =>
-    TypeHandler<Stream<List<int>>>((req, res, dynamic val) async {
+    TypeHandler<Stream<List<int>>>((req, res, Stream<List<int>> val) async {
       if (res.headers.contentType == null ||
           res.headers.contentType!.value == 'text/plain') {
         res.headers.contentType = ContentType.binary;
       }
-      await res.addStream(val as Stream<List<int>>);
+      await res.addStream(val);
       await res.close();
     });

--- a/lib/src/type_handlers/directory_type_handler.dart
+++ b/lib/src/type_handlers/directory_type_handler.dart
@@ -9,15 +9,13 @@ import '../extensions/response_helpers.dart';
 import 'type_handler.dart';
 
 TypeHandler get directoryTypeHandler =>
-    TypeHandler<Directory>((req, res, dynamic directory) async {
+    TypeHandler<Directory>((req, res, Directory directory) async {
       final usedRoute = req.route;
       String? virtualPath;
       if (usedRoute.contains('*')) {
         virtualPath = req.uri.path
             .substring(min(req.uri.path.length, usedRoute.indexOf('*')));
       }
-
-      directory = directory as Directory;
 
       if (req.method == 'GET' || req.method == 'HEAD') {
         assert(usedRoute.contains('*'),

--- a/lib/src/type_handlers/file_type_handler.dart
+++ b/lib/src/type_handlers/file_type_handler.dart
@@ -5,8 +5,7 @@ import '../extensions/response_helpers.dart';
 import 'type_handler.dart';
 
 TypeHandler get fileTypeHandler =>
-    TypeHandler<File>((HttpRequest req, HttpResponse res, dynamic file) async {
-      file = file as File;
+    TypeHandler<File>((HttpRequest req, HttpResponse res, File file) async {
       if (file.existsSync()) {
         res.setContentTypeFromFile(file);
         await res.addStream(file.openRead());

--- a/lib/src/type_handlers/string_type_handler.dart
+++ b/lib/src/type_handlers/string_type_handler.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:alfred/src/type_handlers/type_handler.dart';
 
 TypeHandler<String> get stringTypeHandler =>
-    TypeHandler<String>((HttpRequest req, HttpResponse res, dynamic value) {
+    TypeHandler<String>((HttpRequest req, HttpResponse res, String value) {
       res.write(value);
       return res.close();
     });

--- a/lib/src/type_handlers/type_handler.dart
+++ b/lib/src/type_handlers/type_handler.dart
@@ -1,16 +1,13 @@
 import 'dart:async';
 import 'dart:io';
 
-typedef TypeHandlerFunction<T> = FutureOr Function(HttpRequest req, HttpResponse res, T value);
-
 class TypeHandler<T> {
-  TypeHandler(TypeHandlerFunction<T> handler) : handler = _wrap(handler);
+  TypeHandler(this._handler);
 
-  TypeHandlerFunction<dynamic> handler;
+  FutureOr Function(HttpRequest, HttpResponse, T)  _handler;
+
+  FutureOr handler(HttpRequest req, HttpResponse res, dynamic item)
+      => _handler(req, res, item as T);
 
   bool shouldHandle(dynamic item) => item is T;
-}
-
-TypeHandlerFunction<dynamic> _wrap<T>(TypeHandlerFunction<T> handler) {
-  return (HttpRequest req, HttpResponse res, dynamic value) => handler(req, res, value as T);
 }

--- a/lib/src/type_handlers/type_handler.dart
+++ b/lib/src/type_handlers/type_handler.dart
@@ -1,10 +1,16 @@
 import 'dart:async';
 import 'dart:io';
 
-class TypeHandler<T> {
-  TypeHandler(this.handler);
+typedef TypeHandlerFunction<T> = FutureOr Function(HttpRequest req, HttpResponse res, T value);
 
-  FutureOr Function(HttpRequest req, HttpResponse res, T value) handler;
+class TypeHandler<T> {
+  TypeHandler(TypeHandlerFunction<T> handler) : handler = _wrap(handler);
+
+  TypeHandlerFunction<dynamic> handler;
 
   bool shouldHandle(dynamic item) => item is T;
+}
+
+TypeHandlerFunction<dynamic> _wrap<T>(TypeHandlerFunction<T> handler) {
+  return (HttpRequest req, HttpResponse res, dynamic value) => handler(req, res, value as T);
 }

--- a/lib/src/type_handlers/type_handler.dart
+++ b/lib/src/type_handlers/type_handler.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 class TypeHandler<T> {
   TypeHandler(this._handler);
 
-  FutureOr Function(HttpRequest, HttpResponse, T)  _handler;
+  final FutureOr Function(HttpRequest, HttpResponse, T)  _handler;
 
   FutureOr handler(HttpRequest req, HttpResponse res, dynamic item)
       => _handler(req, res, item as T);

--- a/lib/src/type_handlers/websocket_type_handler.dart
+++ b/lib/src/type_handlers/websocket_type_handler.dart
@@ -5,8 +5,7 @@ import 'package:alfred/src/type_handlers/type_handler.dart';
 
 TypeHandler<WebSocketSession> get websocketTypeHandler =>
     TypeHandler<WebSocketSession>(
-        (HttpRequest req, HttpResponse res, dynamic value) async {
-      value = value as WebSocketSession;
+        (HttpRequest req, HttpResponse res, WebSocketSession value) async {
       var ws = await WebSocketTransformer.upgrade(req);
       value._start(ws);
     });


### PR DESCRIPTION
* build route RegExp once when it is created
* improve null safety semantics in store plugins (tryGet)
* add support for lazy initialization of store values (unset / getOrSet)
* make HttpRequest.params getter lazy
* improve type safety for TypeHandlers