### PR TITLE
Improve route parameter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,31 @@ matching, mostly just stick with the route name and param syntax from Express:
 
 "/path/to/:id/property" etc
 
+The Express syntax has been extended to support parameter patterns and types. To enforce parameter
+validation, a regular expression or a type specifier should be provided after the parameter name, using
+another ":" as a separator:
+
+"/path/to/:id:\d+/property" will ensure "id" is a string consisting of decimal digits
+"/path/to/:id:[0-9a-f]+/property" will ensure "id" is a string consisting of hexadecimal digits
+"/path/to/:id:uuid/property" will ensure "id" is a string representing an UUID
+
+Available built-in types are:
+
+* `int`: a decimal integer
+* * associated regular expression: `-?\d+`
+* `uint`: a positive decimal integer
+* * associated regular expression: `\d+`
+* `double`: a double (dot notation only -- scientific notation is not supported)
+* * associated regular expression: `-?\d+(?:\.\d+)`
+* `date`: a UTC date in the form of "year/month/day"
+* * associated regular expression: `-?\d{1,6}/(?:0[1-9]|1[012])/(?:0[1-9]|[12][0-9]|3[01])`
+* * note how this parameter type "absorbs" multiple segments of the URI
+* `timestamp`: number of milliseconds since Epoch
+* * associated regular expression: `-?\d+`
+* `uuid`: a string ressembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)
+* * associated regular expression: `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`
+* * note that no effort is made to ensure it is a valid UUID
+
 So for example:
 
 ```dart
@@ -160,6 +185,11 @@ import 'package:alfred/alfred.dart';
 
 void main() async {
   final app = Alfred();
+  app.all('/example/:id:int/:name', (req, res) {
+    req.params['id'] != null;
+    req.params['id'] is int;
+    req.params['name'] != null;
+  });
   app.all('/example/:id/:name', (req, res) {
     req.params['id'] != null;
     req.params['name'] != null;

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The big difference you will see is the option to not call `res.send` or `res.jso
 Each route accepts a Future as response. Currently you can pass back the following and it will be sent appropriately:
 
 | Return Dart Type | Returning REST type |
-| ----------------- | ------------------ |
+| ---------------- | ------------------ |
 | `List<dynamic>` | JSON |
 | `Map<String, Object?>` | JSON |
 | Serializable object (Object.toJSON or Object.toJson) * see note | JSON |
@@ -151,32 +151,28 @@ more detail: https://medium.com/@iapicca/alfred-an-express-like-server-framework
 Routing follows a similar pattern to the more basic ExpressJS routes. While there is some regex
 matching, mostly just stick with the route name and param syntax from Express:
 
-"/path/to/:id/property" etc
+* `/path/to/:id/property` etc
 
 The Express syntax has been extended to support parameter patterns and types. To enforce parameter
 validation, a regular expression or a type specifier should be provided after the parameter name, using
-another ":" as a separator:
+another `:` as a separator:
 
-"/path/to/:id:\d+/property" will ensure "id" is a string consisting of decimal digits
-"/path/to/:id:[0-9a-f]+/property" will ensure "id" is a string consisting of hexadecimal digits
-"/path/to/:id:uuid/property" will ensure "id" is a string representing an UUID
+* `/path/to/:id:\d+/property` will ensure "id" is a string consisting of decimal digits
+* `/path/to/:id:[0-9a-f]+/property` will ensure "id" is a string consisting of hexadecimal digits
+* `/path/to/:id:uuid/property` will ensure "id" is a string representing an UUID
 
 Available built-in types are:
 
-* `int`: a decimal integer
-* * associated regular expression: `-?\d+`
-* `uint`: a positive decimal integer
-* * associated regular expression: `\d+`
-* `double`: a double (dot notation only -- scientific notation is not supported)
-* * associated regular expression: `-?\d+(?:\.\d+)`
-* `date`: a UTC date in the form of "year/month/day"
-* * associated regular expression: `-?\d{1,6}/(?:0[1-9]|1[012])/(?:0[1-9]|[12][0-9]|3[01])`
-* * note how this parameter type "absorbs" multiple segments of the URI
-* `timestamp`: number of milliseconds since Epoch
-* * associated regular expression: `-?\d+`
-* `uuid`: a string ressembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)
-* * associated regular expression: `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`
-* * note that no effort is made to ensure it is a valid UUID
+| Builtin Type | Description | Regular Expression |
+| ------------ | ----------- | ------------------ |
+| `int` | A decimal integer | `-?\d+` |
+| `uint` | A positive decimal integer | `\d+` |
+| `double` | A double (dot notation only -- scientific notation is not supported) | `-?\d+(?:\.\d+)` |
+| `date` | A UTC date in the form of "year/month/day" | `-?\d{1,6}/(?:0[1-9]|1[012])/(?:0[1-9]|[12][0-9]|3[01])` |
+| note how this parameter type "absorbs" multiple segments of the URI |
+| `timestamp` | Number of milliseconds since Epoch | `-?\d+` |
+| `uuid` | a string ressembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` |
+| note that no effort is made to ensure it is a valid UUID |
 
 So for example:
 

--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ Available built-in types are:
 
 | Builtin Type | Description | Regular Expression | Dart type |
 | ------------ | ----------- | ------------------ | --------- |
-| `int` | A decimal integer. | `-?\d+` | `int` |
-| `uint` | A positive decimal integer. | `\d+` | `int` |
-| `double` | A double (decimal notation only, scientific notation is not supported) | `-?\d+(?:\.\d+)` | `double` |
-| `date` | A UTC date in the form of "year/month/day"; please note how this parameter type "absorbs" multiple segments of the URI | `-?\d{1,6}/(?:0[1-9]||1[012])/(?:0[1-9]||[12][0-9]||3[01])` | `DateTime` |
-| `timestamp` | Number of milliseconds since Epoch | `-?\d+` | `DateTime` |
-| `uuid` | A string ressembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`); please note that no effort is made to ensure this is a valid UUID | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` |
+| `int` | A decimal integer | `-?\d+` | `int` |
+| `uint` | A positive decimal integer | `\d+` | `int` |
+| `double` | A double (decimal form); note that scientific notation is not supported) | `-?\d+(?:\.\d+)` | `double` |
+| `date` | A UTC date in the form of "year/month/day"; note how this type "absorbs" multiple segments of the URI | `-?\d{1,6}/(?:0[1-9]&#124;1[012])/(?:0[1-9]&#124;[12][0-9]&#124;3[01])` | `DateTime` |
+| `timestamp` | A UTC date expressed in number of milliseconds since Epoch | `-?\d+` | `DateTime` |
+| `uuid` | A string resembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`); please note that no effort is made to ensure this is a valid UUID | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `String` |
 
 So for example:
 

--- a/README.md
+++ b/README.md
@@ -159,18 +159,26 @@ another `:` as a separator:
 
 * `/path/to/:id:\d+/property` will ensure "id" is a string consisting of decimal digits
 * `/path/to/:id:[0-9a-f]+/property` will ensure "id" is a string consisting of hexadecimal digits
+* `/path/to/:word:[a-z]+/property` will ensure "word" is a string consisting of letters only
 * `/path/to/:id:uuid/property` will ensure "id" is a string representing an UUID
 
-Available built-in types are:
+Available type specifiers are:
 
-| Builtin Type | Description | Regular Expression | Dart type |
-| ------------ | ----------- | ------------------ | --------- |
-| `int` | A decimal integer | `-?\d+` | `int` |
-| `uint` | A positive decimal integer | `\d+` | `int` |
-| `double` | A double (decimal form); note that scientific notation is not supported) | `-?\d+(?:\.\d+)` | `double` |
-| `date` | A UTC date in the form of "year/month/day"; note how this type "absorbs" multiple segments of the URI | `-?\d{1,6}/(?:0[1-9]\|1[012])/(?:0[1-9]\|[12][0-9]\|3[01])` | `DateTime` |
-| `timestamp` | A UTC date expressed in number of milliseconds since Epoch | `-?\d+` | `DateTime` |
-| `uuid` | A string resembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`); please note that no effort is made to ensure this is a valid UUID | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `String` |
+* `int`: a decimal integer
+* `uint`: a positive decimal integer
+* `double`: a double (decimal form); note that scientific notation is not supported
+* `date`: a UTC date in the form of "year/month/day"; note how this type "absorbs" multiple segments of the URI
+* `timestamp`: a UTC date expressed in number of milliseconds since Epoch
+* `uuid`: a string resembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`); note that no effort is made to ensure this is a valid UUID
+
+| Type Specifier | Regular Expression | Dart type |
+| -------------- | ------------------ | --------- |
+| `int` | `-?\d+` | `int` |
+| `uint` | `\d+` | `int` |
+| `double` `-?\d+(?:\.\d+)` | `double` |
+| `date` | `-?\d{1,6}/(?:0[1-9]\|1[012])/(?:0[1-9]\|[12][0-9]\|3[01])` | `DateTime` |
+| `timestamp` | `-?\d+` | `DateTime` |
+| `uuid` |  `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `String` |
 
 So for example:
 
@@ -187,6 +195,12 @@ void main() async {
   app.all('/example/:id/:name', (req, res) {
     req.params['id'] != null;
     req.params['name'] != null;
+  });
+  app.get('/blog/:date:date/:id:int', (req, res) {
+    req.params['date'] != null;
+    req.params['date'] is DateTime;
+    req.params['id'] != null;
+    req.params['id'] is int;
   });
   await app.listen();
 }

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Available type specifiers are:
 | -------------- | ------------------ | --------- |
 | `int` | `-?\d+` | `int` |
 | `uint` | `\d+` | `int` |
-| `double` `-?\d+(?:\.\d+)` | `double` |
+| `double` | `-?\d+(?:\.\d+)` | `double` |
 | `date` | `-?\d{1,6}/(?:0[1-9]\|1[012])/(?:0[1-9]\|[12][0-9]\|3[01])` | `DateTime` |
 | `timestamp` | `-?\d+` | `DateTime` |
 | `uuid` |  `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `String` |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Available built-in types are:
 | `int` | A decimal integer | `-?\d+` | `int` |
 | `uint` | A positive decimal integer | `\d+` | `int` |
 | `double` | A double (decimal form); note that scientific notation is not supported) | `-?\d+(?:\.\d+)` | `double` |
-| `date` | A UTC date in the form of "year/month/day"; note how this type "absorbs" multiple segments of the URI | `-?\d{1,6}/(?:0[1-9]&#124;1[012])/(?:0[1-9]&#124;[12][0-9]&#124;3[01])` | `DateTime` |
+| `date` | A UTC date in the form of "year/month/day"; note how this type "absorbs" multiple segments of the URI | `-?\d{1,6}/(?:0[1-9]\|1[012])/(?:0[1-9]\|[12][0-9]\|3[01])` | `DateTime` |
 | `timestamp` | A UTC date expressed in number of milliseconds since Epoch | `-?\d+` | `DateTime` |
 | `uuid` | A string resembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`); please note that no effort is made to ensure this is a valid UUID | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` | `String` |
 

--- a/README.md
+++ b/README.md
@@ -163,16 +163,14 @@ another `:` as a separator:
 
 Available built-in types are:
 
-| Builtin Type | Description | Regular Expression |
-| ------------ | ----------- | ------------------ |
-| `int` | A decimal integer | `-?\d+` |
-| `uint` | A positive decimal integer | `\d+` |
-| `double` | A double (dot notation only -- scientific notation is not supported) | `-?\d+(?:\.\d+)` |
-| `date` | A UTC date in the form of "year/month/day" | `-?\d{1,6}/(?:0[1-9]|1[012])/(?:0[1-9]|[12][0-9]|3[01])` |
-| note how this parameter type "absorbs" multiple segments of the URI |
-| `timestamp` | Number of milliseconds since Epoch | `-?\d+` |
-| `uuid` | a string ressembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` |
-| note that no effort is made to ensure it is a valid UUID |
+| Builtin Type | Description | Regular Expression | Dart type |
+| ------------ | ----------- | ------------------ | --------- |
+| `int` | A decimal integer. | `-?\d+` | `int` |
+| `uint` | A positive decimal integer. | `\d+` | `int` |
+| `double` | A double (decimal notation only, scientific notation is not supported) | `-?\d+(?:\.\d+)` | `double` |
+| `date` | A UTC date in the form of "year/month/day"; please note how this parameter type "absorbs" multiple segments of the URI | `-?\d{1,6}/(?:0[1-9]||1[012])/(?:0[1-9]||[12][0-9]||3[01])` | `DateTime` |
+| `timestamp` | Number of milliseconds since Epoch | `-?\d+` | `DateTime` |
+| `uuid` | A string ressembling a UUID (hexadecimal number formatted as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`); please note that no effort is made to ensure this is a valid UUID | `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}` |
 
 So for example:
 

--- a/example/example_params.dart
+++ b/example/example_params.dart
@@ -2,9 +2,22 @@ import 'package:alfred/alfred.dart';
 
 void main() async {
   final app = Alfred();
+  app.all('/typed-example/:id:int/:name', (req, res) {
+    req.params['id'] != null;
+    req.params['id'] is int;
+    req.params['name'] != null;
+  });
   app.all('/example/:id/:name', (req, res) {
     req.params['id'] != null;
     req.params['name'] != null;
+  });
+  app.get('/blog/:date:date/:id:int', (req, res) {
+    /// will match URI such as /blog/2021/08/23/1
+    /// with date = DateTime.utc(2021, 08, 23) and id = 1
+    req.params['date'] != null;
+    req.params['date'] is DateTime;
+    req.params['id'] != null;
+    req.params['id'] is int;
   });
   await app.listen();
 }

--- a/example/example_routing.dart
+++ b/example/example_routing.dart
@@ -2,6 +2,11 @@ import 'package:alfred/alfred.dart';
 
 void main() async {
   final app = Alfred();
+  app.all('/typed-example/:id:int/:name', (req, res) {
+    req.params['id'] != null;
+    req.params['id'] is int;
+    req.params['name'] != null;
+  });
   app.all('/example/:id/:name', (req, res) {
     req.params['id'] != null;
     req.params['name'] != null;

--- a/lib/alfred.dart
+++ b/lib/alfred.dart
@@ -12,3 +12,4 @@ export 'src/http_route.dart';
 export 'src/middleware/cors.dart';
 export 'src/plugins/store_plugin.dart';
 export 'src/type_handlers/type_handler.dart';
+export 'src/route_param_types/http_route_param_type.dart';

--- a/lib/alfred.dart
+++ b/lib/alfred.dart
@@ -7,6 +7,7 @@ export 'src/extensions/file_helpers.dart';
 export 'src/extensions/nested_route.dart';
 export 'src/extensions/request_helpers.dart';
 export 'src/extensions/response_helpers.dart';
+export 'src/extensions/string_helpers.dart';
 export 'src/http_route.dart';
 export 'src/middleware/cors.dart';
 export 'src/plugins/store_plugin.dart';

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -3,6 +3,14 @@ import 'dart:io';
 
 import 'package:alfred/src/extensions/request_helpers.dart';
 import 'package:alfred/src/plugins/store_plugin.dart';
+import 'package:alfred/src/route_param_types/alpha_param_type.dart';
+import 'package:alfred/src/route_param_types/date_param_type.dart';
+import 'package:alfred/src/route_param_types/double_param_type.dart';
+import 'package:alfred/src/route_param_types/hex_param_type.dart';
+import 'package:alfred/src/route_param_types/int_param_type.dart';
+import 'package:alfred/src/route_param_types/timestamp_param_type.dart';
+import 'package:alfred/src/route_param_types/uint_param_type.dart';
+import 'package:alfred/src/route_param_types/uuid_param_type.dart';
 import 'package:alfred/src/type_handlers/binary_type_handlers.dart';
 import 'package:alfred/src/type_handlers/directory_type_handler.dart';
 import 'package:alfred/src/type_handlers/file_type_handler.dart';
@@ -119,6 +127,7 @@ class Alfred {
     LogType logLevel = LogType.info,
     int simultaneousProcessing = 50,
   }) : requestQueue = Queue(parallel: simultaneousProcessing) {
+    _registerDefaultParamTypes();
     _registerDefaultTypeHandlers();
     _registerPluginListeners();
     _registerDefaultLogWriter(logLevel);
@@ -147,6 +156,19 @@ class Alfred {
       directoryTypeHandler,
       websocketTypeHandler,
       serializableTypeHandler
+    ]);
+  }
+
+  void _registerDefaultParamTypes() {
+    HttpRouteParam.paramTypes.addAll([
+      IntParamType(),
+      UintParamType(),
+      DoubleParamType(),
+      DateParamType(),
+      TimestampParamType(),
+      HexParamType(),
+      AlphaParamType(),
+      UuidParamType()
     ]);
   }
 

--- a/lib/src/extensions/request_helpers.dart
+++ b/lib/src/extensions/request_helpers.dart
@@ -30,13 +30,16 @@ extension RequestHelpers on HttpRequest {
 
   /// Get params
   ///
-  Map<String, String> get params =>
-      store.getOrSet<Map<String, String>>('_internal_params',
-        () => RouteMatcher.getParams(route, uri.path));
+  Map<String, dynamic> get params =>
+      store.tryGet<HttpRouteMatch>('_internal_match')?.params ?? <String, dynamic>{};
+
+  /// Get the matched route URI of the current request
+  ///
+  String get route => store.tryGet<HttpRouteMatch>('_internal_match')?.route.route ?? '';
 
   /// Get the matched route of the current request
   ///
-  String get route => store.tryGet<String>('_internal_route') ?? '';
+  HttpRouteMatch? get match => store.tryGet<HttpRouteMatch>('_internal_match');
 
   /// Get Alfred instance which is associated with this request
   ///

--- a/lib/src/extensions/string_helpers.dart
+++ b/lib/src/extensions/string_helpers.dart
@@ -1,3 +1,8 @@
+enum DecodeMode {
+  AllButSlash,
+  SlashOnly
+}
+
 extension PathNormalizer on String {
   /// Trims all slashes at the start and end
   String get normalizePath {
@@ -8,5 +13,61 @@ extension PathNormalizer on String {
       return substring(0, length - '/'.length).normalizePath;
     }
     return this;
+  }
+
+  static final int _PERCENT = '%'.codeUnitAt(0);
+  static final int _SLASH = '/'.codeUnitAt(0);
+  static final int _ZERO = '0'.codeUnitAt(0);
+  static final int _NINE = '9'.codeUnitAt(0);
+  static final int _UPPER_A = 'A'.codeUnitAt(0);
+  static final int _UPPER_F = 'F'.codeUnitAt(0);
+  static final int _LOWER_A = 'a'.codeUnitAt(0);
+  static final int _LOWER_F = 'f'.codeUnitAt(0);
+
+  int _decodeHex(int codeUnit) {
+    if (_ZERO <= codeUnit && codeUnit <= _NINE) return codeUnit - _ZERO;
+    if (_LOWER_A <= codeUnit && codeUnit <= _LOWER_F) return 10 + codeUnit - _LOWER_A;
+    if (_UPPER_A <= codeUnit && codeUnit <= _UPPER_F) return 10 + codeUnit - _UPPER_A;
+    return -1;
+  }
+
+  int? _getCodeUnit(int hex1, int hex2) {
+    if (hex1 < 0 || hex1 >= 16) return null;
+    if (hex2 < 0 || hex2 >= 16) return null;
+    return 16 * hex1 + hex2;
+  }
+
+  bool _decode(int? value, DecodeMode mode) {
+    if (value == null) return false;
+    switch (mode) {
+      case DecodeMode.AllButSlash: return value != _SLASH;
+      case DecodeMode.SlashOnly: return value == _SLASH;
+    }
+  }
+
+  String decodeUri(DecodeMode mode) {
+    var codes = codeUnits;
+    var changed = false;
+    var pos = 0;
+    while (pos < codes.length) {
+      final char = codes[pos];
+      if (char == _PERCENT) {
+        if (pos + 2 >= length) break;
+        final hex1 = _decodeHex(codes[pos + 1]);
+        final hex2 = _decodeHex(codes[pos + 2]);
+        final value = _getCodeUnit(hex1, hex2);
+        if (_decode(value, mode)) {
+          if (!changed) {
+            // make a copy
+            codes = codes.toList();
+            changed = true;
+          }
+          codes[pos] = value!;
+          codes.removeRange(pos + 1, pos + 3);
+        }
+      }
+      pos++;
+    }
+    return changed ? String.fromCharCodes(codes) : this;
   }
 }

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -6,51 +6,157 @@ import 'extensions/string_helpers.dart';
 import 'alfred.dart';
 
 class HttpRoute {
+  final Method method;
   final String route;
   final FutureOr Function(HttpRequest req, HttpResponse res) callback;
-  final Method method;
   final List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware;
 
-  final RegExp matcher;
+  // The RegExp used to match the input URI
+  late final RegExp matcher;
 
-  /// Returns `true` if route can match multiple routes due to usage of
-  /// wildcards (`*`)
+  // Returns `true` if route can match multiple routes due to usage of
+  // wildcards (`*`)
   final bool usesWildcardMatcher;
 
-  HttpRoute(this.route, this.callback, this.method, {this.middleware = const []})
-    : matcher = _buildMatcher(route), usesWildcardMatcher = route.contains('*');
+  // The route parameters (name, type and pattern)
+  final Map<String, HttpRouteParam> _params = <String, HttpRouteParam>{};
 
-  static RegExp _buildMatcher(String route) {
-    /// Split route path into segments
+  Iterable<HttpRouteParam> get params => _params.values;
+
+  HttpRoute(this.route, this.callback, this.method, {this.middleware = const []})
+    : usesWildcardMatcher = route.contains('*')
+  {
+    // Split route path into segments
     final segments = Uri.parse(route.normalizePath).pathSegments;
 
-    var matcher = '^';
+    var pattern = '^';
     for (var segment in segments) {
       if (segment == '*' &&
           segment != segments.first &&
           segment == segments.last) {
-        /// Generously match path if last segment is wildcard (*)
-        /// Example: 'some/path/*' => should match 'some/path'
-        matcher += '/?.*';
+        // Generously match path if last segment is wildcard (*)
+        // Example: 'some/path/*' => should match 'some/path', 'some/path/', 'some/path/with/children'
+        //                           but not 'some/pathological'
+        pattern += r'(?:/.*|)';
         break;
       } else if (segment != segments.first) {
-        /// Add path separators
-        matcher += '/';
+        // Add path separators
+        pattern += '/';
       }
 
-      /// escape period character
+      // escape period character
       segment = segment.replaceAll('.', r'\.');
 
-      /// parameter (':something') to anything but slash
-      segment = segment.replaceAll(RegExp(':.+'), '[^/]+?');
+      // parse parameter if any
+      final param = HttpRouteParam.tryParse(segment);
+      if (param != null) {
+        if (_params.containsKey(param.name)) throw DuplicateParameterException(param.name);
+        _params[param.name] = param;
+        segment = r'(?<' + param.name + r'>' + param.pattern + ')';
+      }
 
-      /// wildcard ('*') to anything
+      // wildcard ('*') to anything
       segment = segment.replaceAll('*', '.*?');
-
-      matcher += segment;
+      pattern += segment;
     }
-    matcher += r'$';
 
-    return RegExp(matcher, caseSensitive: false);
+    pattern += r'$';
+    matcher = RegExp(pattern, caseSensitive: false);
   }
+}
+
+// Throws when a route contains duplicate parameters
+//
+class DuplicateParameterException implements Exception {
+  DuplicateParameterException(this.name);
+
+  final String name;
+}
+
+/// Class used to retain parameter information (name, type, pattern)
+///
+class HttpRouteParam {
+  HttpRouteParam(this.name, this.pattern, this.type);
+
+  final String name;
+  final String pattern;
+  final HttpRouteParamType? type;
+
+  Object getValue(String value) {
+    value = Uri.decodeComponent(value);
+    switch (type) {
+      case HttpRouteParamType.int:
+        return int.parse(value);
+      case HttpRouteParamType.uint:
+        return int.parse(value);
+      case HttpRouteParamType.double:
+        return double.parse(value);
+      case HttpRouteParamType.date:
+        // note: the RegExp enforces month between 1 and 12 and day between 1 and 31
+        // but it does not care about leap years and actual number of days in month
+        // DateTime will accept "invalid" dates and adjust the result accordingly
+        // eg. 2021-02-31 --> 2021-03-03 
+        final components = value.split('/').map(int.parse).toList();
+        return DateTime.utc(components[0], components[1], components[2]);
+      case HttpRouteParamType.timestamp:
+        return DateTime.fromMillisecondsSinceEpoch(int.parse(value));
+      case HttpRouteParamType.uuid:
+        // Dart does not have a builtin Uuid or Guid type
+        // no effort is made to ensure UUID conforms to RFC4122
+        return value;
+      default:
+        return value;
+    }
+  }
+
+  static HttpRouteParam? tryParse(String segment) {
+    if (!segment.startsWith(':')) return null;
+    HttpRouteParamType? type;
+    var pattern = '';
+    var name = segment.substring(1);
+    final idx = name.indexOf(':');
+    if (idx > 0) {
+      pattern = name.substring(idx + 1);
+      name = name.substring(0, idx);
+      switch (pattern.toLowerCase()) {
+        case 'int':
+          type = HttpRouteParamType.int;
+          pattern = r'-?\d+';
+          break;
+        case 'uint':
+          type = HttpRouteParamType.uint;
+          pattern = r'\d+';
+          break;
+        case 'double':
+          type = HttpRouteParamType.double;
+          pattern = r'-?\d+(?:\.\d+)?';
+          break;
+        case 'date':
+          type = HttpRouteParamType.date;
+          // note: make sure month is in range 01-12 and day is in range 01-31
+          pattern = r'-?\d{1,6}/(?:0[1-9]|1[012])/(?:0[1-9]|[12][0-9]|3[01])';
+          break;
+        case 'timestamp':
+          type = HttpRouteParamType.timestamp;
+          pattern = r'-?\d+';
+          break;
+        case 'uuid':
+          type = HttpRouteParamType.uuid;
+          pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+          break;
+      }
+    } else {
+      pattern = r'[^/]+?';
+    }
+    return HttpRouteParam(name, pattern, type);
+  }
+}
+
+enum HttpRouteParamType {
+  int,
+  uint,
+  double,
+  date,
+  timestamp,
+  uuid
 }

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import '../alfred.dart';
+import 'extensions/string_helpers.dart';
 import 'alfred.dart';
 
 class HttpRoute {
@@ -11,14 +12,13 @@ class HttpRoute {
   final List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware;
 
   final RegExp matcher;
-  final List<String> parts;
-
-  HttpRoute(this.route, this.callback, this.method,
-      {this.middleware = const []}) : matcher = _buildMatcher(route), parts = route.split('/')..remove('');
 
   /// Returns `true` if route can match multiple routes due to usage of
   /// wildcards (`*`)
-  bool get usesWildcardMatcher => route.contains('*');
+  final bool usesWildcardMatcher;
+
+  HttpRoute(this.route, this.callback, this.method, {this.middleware = const []})
+    : matcher = _buildMatcher(route), usesWildcardMatcher = route.contains('*');
 
   static RegExp _buildMatcher(String route) {
     /// Split route path into segments
@@ -32,6 +32,7 @@ class HttpRoute {
         /// Generously match path if last segment is wildcard (*)
         /// Example: 'some/path/*' => should match 'some/path'
         matcher += '/?.*';
+        break;
       } else if (segment != segments.first) {
         /// Add path separators
         matcher += '/';
@@ -51,18 +52,5 @@ class HttpRoute {
     matcher += r'$';
 
     return RegExp(matcher, caseSensitive: false);
-  }
-}
-
-extension _PathNormalizer on String {
-  /// Trims all slashes at the start and end
-  String get normalizePath {
-    if (startsWith('/')) {
-      return substring('/'.length).normalizePath;
-    }
-    if (endsWith('/')) {
-      return substring(0, length - '/'.length).normalizePath;
-    }
-    return this;
   }
 }

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -63,6 +63,9 @@ class HttpRoute {
     pattern += r'$';
     matcher = RegExp(pattern, caseSensitive: false);
   }
+
+  @override
+  String toString() => route;
 }
 
 // Throws when a route contains duplicate parameters
@@ -83,7 +86,8 @@ class HttpRouteParam {
   final HttpRouteParamType? type;
 
   Object getValue(String value) {
-    value = Uri.decodeComponent(value);
+    // path has been decoded already except for '/'
+    value = value.decodeUri(DecodeMode.SlashOnly);
     switch (type) {
       case HttpRouteParamType.int:
         return int.parse(value);
@@ -100,6 +104,10 @@ class HttpRouteParam {
         return DateTime.utc(components[0], components[1], components[2]);
       case HttpRouteParamType.timestamp:
         return DateTime.fromMillisecondsSinceEpoch(int.parse(value));
+      case HttpRouteParamType.hex:
+        return value;
+      case HttpRouteParamType.alpha:
+        return value;
       case HttpRouteParamType.uuid:
         // Dart does not have a builtin Uuid or Guid type
         // no effort is made to ensure UUID conforms to RFC4122
@@ -140,6 +148,14 @@ class HttpRouteParam {
           type = HttpRouteParamType.timestamp;
           pattern = r'-?\d+';
           break;
+        case 'hex':
+          type = HttpRouteParamType.hex;
+          pattern = r'[0-9a-f]+';
+          break;
+        case 'alpha':
+          type = HttpRouteParamType.alpha;
+          pattern = r'[a-z0-9_]+';
+          break;
         case 'uuid':
           type = HttpRouteParamType.uuid;
           pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
@@ -158,5 +174,7 @@ enum HttpRouteParamType {
   double,
   date,
   timestamp,
+  hex,
+  alpha,
   uuid
 }

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -6,7 +6,8 @@ import 'http_route.dart';
 class RouteMatcher {
   static Iterable<HttpRouteMatch> match(
       String input, List<HttpRoute> options, Method method) sync* {
-    final inputPath = Uri.parse(input).path.normalizePath;
+    // decode URL path before matching except for "/"
+    final inputPath = Uri.parse(input).path.normalizePath.decodeUri(DecodeMode.AllButSlash);
 
     for (final option in options) {
       // Check if http method matches

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -4,10 +4,8 @@ import 'alfred.dart';
 import 'http_route.dart';
 
 class RouteMatcher {
-  static List<HttpRoute> match(
-      String input, List<HttpRoute> options, Method method) {
-    final output = <HttpRoute>[];
-
+  static Iterable<HttpRoute> match(
+      String input, List<HttpRoute> options, Method method) sync* {
     final inputPath = Uri.parse(input).path.normalizePath;
 
     for (final option in options) {
@@ -17,11 +15,9 @@ class RouteMatcher {
       }
 
       if (option.matcher.hasMatch(inputPath)) {
-        output.add(option);
+        yield option;
       }
     }
-
-    return output;
   }
 
   static Map<String, String> getParams(String route, String input) {

--- a/lib/src/route_matcher.dart
+++ b/lib/src/route_matcher.dart
@@ -4,49 +4,53 @@ import 'alfred.dart';
 import 'http_route.dart';
 
 class RouteMatcher {
-  static Iterable<HttpRoute> match(
+  static Iterable<HttpRouteMatch> match(
       String input, List<HttpRoute> options, Method method) sync* {
     final inputPath = Uri.parse(input).path.normalizePath;
 
     for (final option in options) {
-      /// Check if http method matches
+      // Check if http method matches
       if (option.method != method && option.method != Method.all) {
         continue;
       }
 
-      if (option.matcher.hasMatch(inputPath)) {
-        yield option;
-      }
-    }
-  }
-
-  static Map<String, String> getParams(String route, String input) {
-    final routeParts = route.split('/')..remove('');
-    final inputParts = input.split('/')..remove('');
-
-    if (inputParts.length != routeParts.length) {
-      throw NotMatchingRouteException();
-    }
-
-    final output = <String, String>{};
-
-    for (var i = 0; i < routeParts.length; i++) {
-      final routePart = routeParts[i];
-      final inputPart = inputParts[i];
-
-      if (routePart.contains(':')) {
-        final routeParams = routePart.split(':')..remove('');
-
-        for (var item in routeParams) {
-          output[item] = Uri.decodeComponent(inputPart);
+      // Match against route RegExp and capture params if valid
+      final match = option.matcher.firstMatch(inputPath);
+      if (match != null) {
+        final routeMatch = HttpRouteMatch.tryParse(option, match);
+        if (routeMatch != null) {
+          yield routeMatch;
         }
       }
     }
-    return output;
   }
 }
 
-/// Throws when trying to extract params and the route you are extracting from
-/// does not match the supplied pattern
+/// Retains the matched route and parameter values extracted
+/// from the Uri
 ///
-class NotMatchingRouteException implements Exception {}
+class HttpRouteMatch {
+  HttpRouteMatch._(this.route, this.params);
+
+  static HttpRouteMatch? tryParse(HttpRoute route, RegExpMatch match) {
+    try {
+      final params = <String, dynamic>{};
+      for (var param in route.params) {
+        var value = match.namedGroup(param.name);
+        if (value == null) {
+          if (param.pattern != '*') {
+            return null;
+          }
+          value = '';
+        }
+        params[param.name] = param.getValue(value);
+      }
+      return HttpRouteMatch._(route, params);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  final HttpRoute route;
+  final Map<String, dynamic> params;
+}

--- a/lib/src/route_param_types/alpha_param_type.dart
+++ b/lib/src/route_param_types/alpha_param_type.dart
@@ -1,0 +1,13 @@
+import 'http_route_param_type.dart';
+
+class AlphaParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'alpha';
+
+  @override
+  final String pattern = r'[0-9a-z_]+';
+
+  @override
+  String parse(String value) => value;
+}

--- a/lib/src/route_param_types/date_param_type.dart
+++ b/lib/src/route_param_types/date_param_type.dart
@@ -1,0 +1,20 @@
+import 'http_route_param_type.dart';
+
+class DateParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'date';
+
+  @override
+  final String pattern =  r'-?\d{1,6}/(?:0[1-9]|1[012])/(?:0[1-9]|[12][0-9]|3[01])';
+
+  @override
+  DateTime parse(String value) {
+    // note: the RegExp enforces month between 1 and 12 and day between 1 and 31
+    // but it does not care about leap years and actual number of days in month
+    // DateTime will accept "invalid" dates and adjust the result accordingly
+    // eg. 2021-02-31 --> 2021-03-03 
+    final components = value.split('/').map(int.parse).toList();
+    return DateTime.utc(components[0], components[1], components[2]);
+  }
+}

--- a/lib/src/route_param_types/double_param_type.dart
+++ b/lib/src/route_param_types/double_param_type.dart
@@ -1,0 +1,13 @@
+import 'http_route_param_type.dart';
+
+class DoubleParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'double';
+
+  @override
+  final String pattern = r'-?\d+(?:\.\d+)?';
+
+  @override
+  double parse(String value) => double.parse(value);
+}

--- a/lib/src/route_param_types/hex_param_type.dart
+++ b/lib/src/route_param_types/hex_param_type.dart
@@ -1,0 +1,13 @@
+import 'http_route_param_type.dart';
+
+class HexParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'hex';
+
+  @override
+  final String pattern = r'[0-9a-f]+';
+
+  @override
+  String parse(String value) => value;
+}

--- a/lib/src/route_param_types/http_route_param_type.dart
+++ b/lib/src/route_param_types/http_route_param_type.dart
@@ -1,0 +1,5 @@
+abstract class HttpRouteParamType {
+  String get name;
+  String get pattern;
+  dynamic parse(String value);
+}

--- a/lib/src/route_param_types/int_param_type.dart
+++ b/lib/src/route_param_types/int_param_type.dart
@@ -1,0 +1,13 @@
+import 'http_route_param_type.dart';
+
+class IntParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'int';
+
+  @override
+  final String pattern = r'-?\d+';
+
+  @override
+  int parse(String value) => int.parse(value);
+}

--- a/lib/src/route_param_types/timestamp_param_type.dart
+++ b/lib/src/route_param_types/timestamp_param_type.dart
@@ -1,0 +1,13 @@
+import 'http_route_param_type.dart';
+
+class TimestampParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'timestamp';
+
+  @override
+  final String pattern = r'-?\d+';
+
+  @override
+  DateTime parse(String value) => DateTime.fromMillisecondsSinceEpoch(int.parse(value));
+}

--- a/lib/src/route_param_types/uint_param_type.dart
+++ b/lib/src/route_param_types/uint_param_type.dart
@@ -1,0 +1,13 @@
+import 'http_route_param_type.dart';
+
+class UintParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'uint';
+
+  @override
+  final String pattern = r'\d+';
+
+  @override
+  int parse(String value) => int.parse(value);
+}

--- a/lib/src/route_param_types/uuid_param_type.dart
+++ b/lib/src/route_param_types/uuid_param_type.dart
@@ -1,0 +1,17 @@
+import 'http_route_param_type.dart';
+
+class UuidParamType implements HttpRouteParamType {
+
+  @override
+  final String name = 'uuid';
+
+  @override
+  final String pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+  @override
+  String parse(String value) {
+    // Dart does not have a builtin Uuid or Guid type
+    // no effort is made to ensure UUID conforms to RFC4122
+    return value;
+  }
+}

--- a/lib/src/type_handlers/type_handler.dart
+++ b/lib/src/type_handlers/type_handler.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 class TypeHandler<T> {
   TypeHandler(this._handler);
 
-  FutureOr Function(HttpRequest, HttpResponse, T)  _handler;
+  final FutureOr Function(HttpRequest, HttpResponse, T)  _handler;
 
   FutureOr handler(HttpRequest req, HttpResponse res, dynamic item)
       => _handler(req, res, item as T);

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -165,8 +165,8 @@ void main() {
     /// TODO: Need to find a way to send an options request. The HTTP library doesn't
     /// seem to support it.
     ///
-    // final response = await http.head(Uri.parse("http://localhost:$port/test"));
-    // expect(response.body, "test string");
+    // final response = await http.options(Uri.parse('http://localhost:$port/test'));
+    // expect(response.body, 'test string');
   });
 
   test('it handles a HEAD request', () async {
@@ -419,6 +419,34 @@ void main() {
     app.get('/test/:id', (req, res) => req.params['id']);
     final response =
         await http.get(Uri.parse('http://localhost:$port/test/15'));
+    expect(response.body, '15');
+  });
+
+  test('it handles typed params', () async {
+    app.get('/blog/:year:int', (req, res) => 'Blog Entries for year ${req.params['year']}');
+    app.get('/blog/:date:date', (req, res) => 'Blog Entries for ${req.params['date']}');
+    app.get('/blog/:date:date/:id:uint/:title:*', (req, res) => 'Blog Entry #${req.params['id']} - ${req.params['date']} - ${req.params['title']}');
+    var response =
+        await http.get(Uri.parse('http://localhost:$port/blog/2021/03/27/1/Initial%20Commit'));
+    expect(response.body, 'Blog Entry #1 - ${DateTime.utc(2021, 3, 27)} - Initial Commit');
+    response =
+        await http.get(Uri.parse('http://localhost:$port/blog/2021/08/20/59/Merged%20commit%20c391fcc'));
+    expect(response.body, 'Blog Entry #59 - ${DateTime.utc(2021, 8, 20)} - Merged commit c391fcc');
+    response =
+        await http.get(Uri.parse('http://localhost:$port/blog/2021'));
+    expect(response.body, 'Blog Entries for year 2021');
+    response =
+        await http.get(Uri.parse('http://localhost:$port/blog/2021/08/20'));
+    expect(response.body, 'Blog Entries for ${DateTime.utc(2021, 8, 20)}');
+  });
+
+  test('it handles params in routes with wildcards', () async {
+    app.get('/test/*/:id', (req, res) => req.params['id']);
+    var response =
+        await http.get(Uri.parse('http://localhost:$port/test/onelevel/15'));
+    expect(response.body, '15');
+    response =
+        await http.get(Uri.parse('http://localhost:$port/test/two/levels/15'));
     expect(response.body, '15');
   });
 

--- a/test/extensions/string_helpers_test.dart
+++ b/test/extensions/string_helpers_test.dart
@@ -1,0 +1,47 @@
+import 'package:test/test.dart';
+
+import 'package:alfred/alfred.dart';
+
+void main() {
+  test('it should normalize path', () {
+    expect('/test'.normalizePath, 'test');
+    expect('test/'.normalizePath, 'test');
+    expect('/test/'.normalizePath, 'test');
+    expect('//test'.normalizePath, 'test');
+    expect('test//'.normalizePath, 'test');
+    expect('//test//'.normalizePath, 'test');
+    expect('/multiple/segments/'.normalizePath, 'multiple/segments');
+    expect('//multiple//segments//'.normalizePath, 'multiple//segments');
+  });
+
+  test('it should decode URI path except for "%2F" (slash)', () {
+    // first make sure Uri.parse() behaves as expected
+    expect(Uri.parse('/%31').path, '/1');
+    expect(Uri.parse('/%61').path, '/a');
+    expect(Uri.parse('/%6').path, '/%256'); // invalid escape sequences have their percent character encoded when parsed
+    expect(Uri.parse('/abc%20def/').path, '/abc%20def/'); // %20 is not decoded (space ' ')
+    expect(Uri.parse('/abc%25def/').path, '/abc%25def/'); // %25 is not decoded (percent '%')
+    expect(Uri.parse('/abc%2Fdef/').path, '/abc%2Fdef/'); // %2F is not decoded (slash '/')
+    expect(Uri.parse('/abc%3Fdef/').path, '/abc%3Fdef/'); // %3F is not decoded (question mark '?')
+
+    // before matching, URI path must be decoded except for "%2F"
+    expect(_decodePath('/%61'), 'a');
+    expect(_decodePath('/%61bc'), 'abc');
+    expect(_decodePath('/%61bc/def/'), 'abc/def');
+    expect(_decodePath('/%6'), '%6');
+    expect(_decodePath('/abc%20def/'), 'abc def');    // decode escape sequence for space ' '
+    expect(_decodePath('/abc%25def/'), 'abc%def');    // decode escape sequence for percent '%'
+    expect(_decodePath('/abc%2Fdef/'), 'abc%2Fdef');  // do not decode escape sequence for slash '/'
+    expect(_decodePath('/abc%3Fdef/'), 'abc?def');    // decode escape sequence for question mark '?'
+
+    // after matching, a segment containing %2F must be decoded
+    expect(_decodeSegment('abc%2Fdef'), 'abc/def');
+    expect(_decodeSegment('abc%31'), 'abc%31');       // eg. from path /abc%2531/
+  });
+}
+
+String _decodePath(String path)
+  => Uri.parse(path).path.normalizePath.decodeUri(DecodeMode.AllButSlash);
+
+String _decodeSegment(String segment)
+  => segment.decodeUri(DecodeMode.SlashOnly);

--- a/test/route_matcher_test.dart
+++ b/test/route_matcher_test.dart
@@ -5,168 +5,300 @@ import 'package:test/test.dart';
 void main() {
   test('it should match routes correctly', () {
     final testRoutes = [
-      HttpRoute('/a/:id/go', _callback, Method.get),
-      HttpRoute('/a', _callback, Method.get),
-      HttpRoute('/b/a/:input/another', _callback, Method.get),
-      HttpRoute('/b/a/:input', _callback, Method.get),
-      HttpRoute('/b/B/:input', _callback, Method.get),
-      HttpRoute('/[a-z]/yep', _callback, Method.get),
+      httpTestRoute('/a/:id/go'),
+      httpTestRoute('/a'),
+      httpTestRoute('/b/a/:input/another'),
+      httpTestRoute('/b/a/:input'),
+      httpTestRoute('/b/B/:input'),
+      httpTestRoute('/[a-z]/yep'),
     ];
 
-    expect(match('/a', testRoutes), ['/a']);
-    expect(match('/a?query=true', testRoutes), ['/a']);
-    expect(match('/a/123/go', testRoutes), ['/a/:id/go']);
-    expect(match('/a/123/go/a', testRoutes), <String>[]);
-    expect(match('/b/a/adskfjasjklf/another', testRoutes),
+    expect(patterns(match('/a', testRoutes)),
+        ['/a']);
+    expect(patterns(match('/a?query=true', testRoutes)),
+        ['/a']);
+    expect(patterns(match('/a/123/go', testRoutes)),
+        ['/a/:id/go']);
+    expect(patterns(match('/a/123/go/a', testRoutes)),
+        isEmpty);
+    expect(patterns(match('/b/a/adskfjasjklf/another', testRoutes)),
         ['/b/a/:input/another']);
-    expect(match('/b/a/adskfjasj', testRoutes), ['/b/a/:input']);
-    expect(match('/d/yep', testRoutes), ['/[a-z]/yep']);
-    expect(match('/b/B/yep', testRoutes), ['/b/B/:input']);
+    expect(patterns(match('/b/a/adskfjasj', testRoutes)),
+        ['/b/a/:input']);
+    expect(patterns(match('/d/yep', testRoutes)),
+        ['/[a-z]/yep']);
+    expect(patterns(match('/b/B/yep', testRoutes)),
+        ['/b/B/:input']);
+  });
+
+  test('it should match routes correctly - typed parameters', () {
+    final patternRoute = httpTestRoute(r'/xxx/:value1:\d+/:value2');
+    final intRoute = httpTestRoute(r'/xxx/:value1:int/:value2');
+    final uintRoute = httpTestRoute(r'/xxx/:value1:uint/:value2');
+    final doubleRoute = httpTestRoute(r'/xxx/:value1:double/:value2');
+    final dateRoute = httpTestRoute(r'/xxx/:value1:date/:value2');
+    final tsRoute = httpTestRoute(r'/xxx/:value1:timestamp/:value2');
+    final uuidRoute = httpTestRoute(r'/xxx/:value1:uuid/:value2');
+    final genericRoute = httpTestRoute(r'/xxx/:value1/:value2');
+
+    final testRoutes = [
+      patternRoute, intRoute, uintRoute,
+      doubleRoute, dateRoute, tsRoute,
+      uuidRoute, genericRoute
+    ];
+
+    expect(routes(match('/xxx/123/test', testRoutes)),
+        [ patternRoute, intRoute, uintRoute,
+          doubleRoute, tsRoute, genericRoute ]);
+    expect(routes(match('/xxx/-123/test', testRoutes)),
+        [ intRoute, doubleRoute,
+          tsRoute, genericRoute ]);
+    expect(routes(match('/xxx/123.4/test', testRoutes)),
+        [ doubleRoute, genericRoute ]);
+    expect(routes(match('/xxx/-123.4/test', testRoutes)),
+        [ doubleRoute, genericRoute ]);
+    expect(routes(match('/xxx/2021/08/23/test', testRoutes)),
+        [ dateRoute ]);
+    expect(routes(match('/xxx/-52/08/23/test', testRoutes)),
+        [ dateRoute ]);
+    expect(routes(match('/xxx/01234567-0123-4567-89ab-cdef01234567/test', testRoutes)),
+        [ uuidRoute, genericRoute ]);
+    expect(routes(match('/xxx/name/test', testRoutes)),
+        [ genericRoute ]);
   });
 
   test('it should match wildcards', () {
     final testRoutes = [
-      HttpRoute('*', _callback, Method.get),
-      HttpRoute('/a', _callback, Method.get),
-      HttpRoute('/b', _callback, Method.get),
+      httpTestRoute('*'),
+      httpTestRoute('/a'),
+      httpTestRoute('/b'),
     ];
 
-    expect(match('/a', testRoutes), ['*', '/a']);
+    expect(patterns(match('/a', testRoutes)),
+        ['*', '/a']);
   });
 
   test('it should generously match wildcards for sub-paths', () {
     final testRoutes = [
-      HttpRoute('path/*', _callback, Method.get),
+      httpTestRoute('/some/path/*'),
+      httpTestRoute('/some/path*'),
     ];
 
-    expect(match('/path/to', testRoutes), ['path/*']);
-    expect(match('/path/', testRoutes), ['path/*']);
-    expect(match('/path', testRoutes), ['path/*']);
+    expect(patterns(match('/some/path/to', testRoutes)),
+        ['/some/path/*', '/some/path*']);
+    expect(patterns(match('/some/path/to/something/else', testRoutes)),
+        ['/some/path/*', '/some/path*']);
+    expect(patterns(match('/some/path/', testRoutes)),
+        ['/some/path/*', '/some/path*']);
+    expect(patterns(match('/some/path', testRoutes)),
+        ['/some/path/*', '/some/path*']);
+    expect(patterns(match('/some/pathological', testRoutes)),
+        ['/some/path*']);
   });
 
   test('it should respect the route method', () {
     final testRoutes = [
-      HttpRoute('*', _callback, Method.post),
-      HttpRoute('/a', _callback, Method.get),
-      HttpRoute('/b', _callback, Method.get),
+      httpTestRoute('*', Method.post),
+      httpTestRoute('/a', Method.get),
+      httpTestRoute('/b', Method.get),
     ];
 
-    expect(match('/a', testRoutes), ['/a']);
+    expect(patterns(match('/a', testRoutes)),
+        ['/a']);
   });
 
   test('it should extract the route params correctly', () {
-    expect(
-        RouteMatcher.getParams(
-            '/a/:value/:value2', '/a/input/Item%20inventory%20summary'),
-        {
-          'value': 'input',
-          'value2': 'Item inventory summary',
-        });
+    final paramRoute = httpTestRoute('/xxx/:value/:value2');
+
+    final matches = match('/xxx/input/Item%20inventory%20summary', [ paramRoute ]);
+    expect(routes(matches),
+        [ paramRoute ]);
+    expect(params(matches),
+        [ {
+            'value': 'input',
+            'value2': 'Item inventory summary'
+        } ]
+    );
+  });
+
+  test('it should extract the route params correctly - typed parameters', () {
+    final dateRoute = httpTestRoute('/xxx/:value:date');
+    final intRoute = httpTestRoute('/xxx/:value:int');
+    final uintRoute = httpTestRoute('/xxx/:value:uint');
+    final uuidRoute = httpTestRoute('/xxx/:value:uuid');
+    final doubleRoute = httpTestRoute('/xxx/:value:double');
+    final tsRoute = httpTestRoute('/xxx/:value:timestamp');
+
+    final testRoutes = [ 
+        dateRoute, intRoute, uintRoute,
+        uuidRoute, doubleRoute, tsRoute
+    ];
+
+    var matches = match('/xxx/2021/02/32', testRoutes);
+    expect(routes(matches), isEmpty);
+    matches = match('/xxx/2021/13/01', testRoutes);
+    expect(routes(matches), isEmpty);
+
+    matches = match('/xxx/2021/08/23', testRoutes);
+    expect(routes(matches), 
+        [ dateRoute ]);
+    expect(params(matches), 
+        [ { 'value': DateTime.utc(2021, DateTime.august, 23) } ]);
+
+    matches = match('/xxx/2021/02/31', testRoutes);
+    expect(routes(matches), 
+        [ dateRoute ]);
+    expect(params(matches),
+        [ { 'value': DateTime.utc(2021, DateTime.march, 3) } ]);
+
+    matches = match('/xxx/-52/09/11', testRoutes);
+    expect(routes(matches), 
+        [ dateRoute ]);
+    expect(params(matches), 
+        [ { 'value': DateTime.utc(-52, DateTime.september, 11) } ]);
+
+    matches = match('/xxx/12345', testRoutes);
+    expect(routes(matches), 
+        [ intRoute,  uintRoute, doubleRoute, tsRoute ]);
+    expect(params(matches), 
+        [ { 'value': 12345 }, { 'value': 12345 }, { 'value': 12345.0 },
+          { 'value': DateTime.fromMillisecondsSinceEpoch(12345) } ]);
+
+    matches = match('/xxx/-12345', testRoutes);
+    expect(routes(matches),
+        [ intRoute, doubleRoute, tsRoute ]);
+    expect(params(matches),
+        [ { 'value': -12345 }, { 'value': -12345.0 },
+          { 'value': DateTime.fromMillisecondsSinceEpoch(-12345) } ]);
+
+    matches = match('/xxx/-12345.34', testRoutes);
+    expect(routes(matches), [ doubleRoute ]);
+    expect(params(matches), [ { 'value': -12345.34 } ]);
+
+    matches = match('/xxx/01234567-89ab-cdef-0123-456789abcdef', testRoutes);
+    expect(routes(matches), [ uuidRoute ]);
+    expect(params(matches), [ { 'value': '01234567-89ab-cdef-0123-456789abcdef' } ]);
   });
 
   test('it should correctly match routes that have a partial match', () {
     final testRoutes = [
-      HttpRoute('/image', _callback, Method.get),
-      HttpRoute('/imageSource', _callback, Method.get)
+      httpTestRoute('/image'),
+      httpTestRoute('/imageSource')
     ];
 
-    expect(
-        RouteMatcher.match('/imagesource', testRoutes, Method.get)
-            .map((e) => e.route)
-            .toList(),
+    expect(patterns(match('/imagesource', testRoutes)),
         ['/imageSource']);
   });
 
-  test('it handles a dodgy getParams request', () {
-    var hitError = false;
-
-    try {
-      RouteMatcher.getParams('/id/:id/abc', '/id/10');
-    } on NotMatchingRouteException catch (_) {
-      hitError = true;
-    }
-    expect(hitError, true);
-  });
-
   test('it should ignore a trailing slash', () {
-    final testRoutes = [
-      HttpRoute('/b/', _callback, Method.get),
-    ];
+    final testRoute = httpTestRoute('/b/');
 
-    expect(match('/b?qs=true', testRoutes), ['/b/']);
+    expect(routes(match('/b?qs=true', [ testRoute ])),
+        [ testRoute ]);
   });
 
   test('it should ignore a trailing slash in reverse', () {
-    final testRoutes = [
-      HttpRoute('/b', _callback, Method.get),
-    ];
+    final testRoute = httpTestRoute('/b');
 
-    expect(match('/b/?qs=true', testRoutes), ['/b']);
+    expect(routes(match('/b/?qs=true', [ testRoute ])),
+        [ testRoute ]);
   });
 
   test('it should hit a wildcard route halfway through the uri', () {
     final testRoutes = [
-      HttpRoute('/route/*', _callback, Method.get),
-      HttpRoute('/route/route2', _callback, Method.get),
+      httpTestRoute('/route/*'),
+      httpTestRoute('/route/route2'),
     ];
 
-    expect(match('/route/route2', testRoutes), ['/route/*', '/route/route2']);
+    expect(patterns(match('/route/route2', testRoutes)),
+        ['/route/*', '/route/route2']);
   });
 
   test('it should hit a wildcard route halfway through the uri - sibling', () {
     final testRoutes = [
-      HttpRoute('/route*', _callback, Method.get),
-      HttpRoute('/route', _callback, Method.get),
-      HttpRoute('/route/test', _callback, Method.get),
+      httpTestRoute('/route*'),
+      httpTestRoute('/route'),
+      httpTestRoute('/route/test'),
     ];
 
-    expect(match('/route', testRoutes), ['/route*', '/route']);
+    expect(patterns(match('/route', testRoutes)),
+        ['/route*', '/route']);
 
-    expect(match('/route/test', testRoutes), ['/route*', '/route/test']);
+    expect(patterns(match('/route/test', testRoutes)),
+        ['/route*', '/route/test']);
   });
 
   test('it should match wildcards in the middle', () {
     final testRoutes = [
-      HttpRoute('/a/*/b', _callback, Method.get),
-      HttpRoute('/a/*/*/b', _callback, Method.get),
+      httpTestRoute('/a/*/b'),
+      httpTestRoute('/a/*/*/b'),
     ];
 
-    expect(match('/a', testRoutes), <String>[]);
-    expect(match('/a/x/b', testRoutes), ['/a/*/b']);
-    expect(match('/a/x/y/b', testRoutes), ['/a/*/b', '/a/*/*/b']);
+    expect(match('/a', testRoutes),
+        isEmpty);
+    expect(patterns(match('/a/x/b', testRoutes)),
+        ['/a/*/b']);
+    expect(patterns(match('/a/x/y/b', testRoutes)),
+        ['/a/*/b', '/a/*/*/b']);
   });
 
   test('it should match wildcards at the beginning', () {
-    final testRoutes = [
-      HttpRoute('*.jpg', _callback, Method.get),
-    ];
+    final jpgRoute = httpTestRoute('*.jpg');
 
-    expect(match('xjpg', testRoutes), <String>[]);
-    expect(match('.jpg', testRoutes), <String>['*.jpg']);
-    expect(match('path/to/picture.jpg', testRoutes), <String>['*.jpg']);
+    final testRoutes = [ jpgRoute ];
+
+    expect(match('xjpg', testRoutes),
+        isEmpty);
+    expect(routes(match('.jpg', testRoutes)),
+        [ jpgRoute ]);
+    expect(routes(match('path/to/picture.jpg', testRoutes)), 
+        [ jpgRoute ]);
   });
 
   test('it should match regex expressions within segments', () {
     final testRoutes = [
-      HttpRoute('[a-z]+/[0-9]+', _callback, Method.get),
-      HttpRoute('[a-z]{5}', _callback, Method.get),
-      HttpRoute('(a|b)/c', _callback, Method.get),
+      httpTestRoute('[a-z]+/[0-9]+'),
+      httpTestRoute('[a-z]{5}'),
+      httpTestRoute('(a|b)/c'),
     ];
 
-    expect(match('a/b', testRoutes), <String>[]);
-    expect(match('3/a', testRoutes), <String>[]);
-    expect(match('x/323', testRoutes), <String>['[a-z]+/[0-9]+']);
-    expect(match('answer/42', testRoutes), <String>['[a-z]+/[0-9]+']);
-    expect(match('abc', testRoutes), <String>[]);
-    expect(match('abc42', testRoutes), <String>[]);
-    expect(match('abcde', testRoutes), <String>['[a-z]{5}']);
-    expect(match('final', testRoutes), <String>['[a-z]{5}']);
-    expect(match('a/c', testRoutes), <String>['(a|b)/c']);
-    expect(match('b/c', testRoutes), <String>['(a|b)/c']);
+    expect(match('a/b', testRoutes),
+        isEmpty);
+    expect(match('3/a', testRoutes),
+        isEmpty);
+    expect(match('abc', testRoutes),
+        isEmpty);
+    expect(match('abc42', testRoutes),
+        isEmpty);
+    expect(patterns(match('x/323', testRoutes)), 
+        ['[a-z]+/[0-9]+']);
+    expect(patterns(match('answer/42', testRoutes)),
+        ['[a-z]+/[0-9]+']);
+    expect(patterns(match('abcde', testRoutes)),
+        ['[a-z]{5}']);
+    expect(patterns(match('final', testRoutes)), 
+        ['[a-z]{5}']);
+    expect(patterns(match('a/c', testRoutes)), 
+        ['(a|b)/c']);
+    expect(patterns(match('b/c', testRoutes)), 
+        ['(a|b)/c']);
   });
 }
 
-List<String> match(String input, List<HttpRoute> routes) =>
-    RouteMatcher.match(input, routes, Method.get).map((e) => e.route).toList();
+HttpRoute httpTestRoute(String route, [ Method method = Method.get ]) =>
+    HttpRoute(route, _callback, method);
 
-Future Function(HttpRequest, HttpResponse) get _callback => (req, res) async {};
+List<HttpRouteMatch> match(String input, List<HttpRoute> routes) =>
+    RouteMatcher.match(input, routes, Method.get).toList();
+
+List<HttpRoute> routes(Iterable<HttpRouteMatch> matches) =>
+    matches.map((e) => e.route).toList();
+
+List<String> patterns(Iterable<HttpRouteMatch> matches) =>
+    matches.map((e) => e.route.route).toList();
+
+List<Map<String, dynamic>> params(Iterable<HttpRouteMatch> matches) =>
+    matches.map((e) => e.params).toList();
+
+Future Function(HttpRequest, HttpResponse) get _callback =>
+    (req, res) async {};

--- a/test/type_handlers/directory_type_handler_test.dart
+++ b/test/type_handlers/directory_type_handler_test.dart
@@ -90,6 +90,7 @@ void main() {
 
     final response =
         await http.delete(Uri.parse('http://localhost:$port/test/tmp.jpg'));
+    expect(response.statusCode, 200);
     expect(fileToDelete.existsSync(), false);
   });
 


### PR DESCRIPTION
* capture parameters at match time, thus avoiding additional parsing when user code accesses a parameter. This also fixes an issue with routes mixing wildcards and parameters.
* handle URL encoded characters when matching routes and parameters (%2F, %20, %25...)
* ensure matching of routes ending with a "*" segment is not too generous
* add support for parameter validation via regexp or type specifiers
* make parameter validation extensible and customizable