### PR TITLE
chore: Keeping project up-to-date

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,12 +1,17 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
-#linter:
-#  rules:
+linter:
+ rules:
+    constant_identifier_names: false
+    non_constant_identifier_names: false
+    prefer_void_to_null: false
+    avoid_function_literals_in_foreach_calls: false
+    void_checks: false
 
 analyzer:
   exclude: [build/**]

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:enum_to_string/enum_to_string.dart';
 import 'package:queue/queue.dart';
 
 import 'extensions/request_helpers.dart';
@@ -138,7 +137,7 @@ class Alfred {
     logWriter = (dynamic Function() messageFn, type) {
       if (type.index >= logLevel.index) {
         var timestamp = DateTime.now();
-        var logType = EnumToString.convertToString(type);
+        var logType = type.name;
         var message = messageFn().toString();
         print('$timestamp - $logType - $message');
       }
@@ -297,10 +296,10 @@ class Alfred {
 
     // Work out all the routes we need to process
     final effectiveMatches = RouteMatcher.match(
-        request.uri.toString(),
-        routes,
-        EnumToString.fromString<Method>(Method.values, request.method) ??
-            Method.get);
+      request.uri.toString(),
+      routes,
+      Method.values.byName(request.method.toLowerCase()),
+    );
 
     try {
       // If there are no effective routes, that means we need to throw a 404

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -294,11 +294,20 @@ class Alfred {
       logWriter(() => 'Response sent to client', LogType.debug);
     }));
 
+    /// Parse request to Method enum value.
+    Method _parseMethod(HttpRequest request) {
+      try {
+        return Method.values.byName(request.method.toLowerCase());
+      } on ArgumentError {
+        return Method.get;
+      }
+    }
+
     // Work out all the routes we need to process
     final effectiveMatches = RouteMatcher.match(
       request.uri.toString(),
       routes,
-      Method.values.byName(request.method.toLowerCase()),
+      _parseMethod(request),
     );
 
     try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,6 @@ dependencies:
 dev_dependencies:
   test: ^1.14.4
   web_socket_channel: ^2.0.0
+  lints: ^1.0.1
   logging: ^1.0.1
   http: ^0.13.2
-  pedantic: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   mime: ^1.0.0
   mime_type: ^1.0.0
-  enum_to_string: ^2.0.1
   queue: ^3.1.0
 
 dev_dependencies:

--- a/test/benchmarker.dart
+++ b/test/benchmarker.dart
@@ -1,5 +1,6 @@
+import 'dart:async';
+
 import 'package:http/http.dart' as http;
-import 'package:pedantic/pedantic.dart';
 import 'package:queue/queue.dart';
 
 void main() async {


### PR DESCRIPTION
The project was using the package [enum_to_string](https://pub.dev/packages/enum_to_string) for converting Enum objects to String and vice versa. Since dart 2.15 this functionality ships with dart core library. So there is no need for a third-party package. 

The next thing was the project was using [pedantic](https://pub.dev/packages/pedantic) linter. Pedantic was discontinued by google and no one is maintaining the package now. 

So, in this PR, I have removed the dependency [enum_to_string](https://pub.dev/packages/enum_to_string) and replaced [pedantic](https://pub.dev/packages/pedantic) by [lints](https://pub.dev/packages/lints) which is also the lint recommendation from the Dart team. 

_PS After adding [lints](https://pub.dev/packages/lints) there was some more linter message showing up. For now, I have suppressed them. Just to get maintainers to opinion on following the additional linter rules._ 