### PR TITLE
Adding SSL Certificate Support

### DIFF
--- a/example/example_ssl.dart
+++ b/example/example_ssl.dart
@@ -17,7 +17,7 @@ void main() async {
   context.useCertificateChain(chain);
   context.usePrivateKey(key);
 
-  await app.listenSecurity(
+  await app.listenSecure(
     port: 3000,
     securityContext: context,
   );

--- a/example/example_ssl.dart
+++ b/example/example_ssl.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:alfred/alfred.dart';
+
+void main() async {
+  final app = Alfred();
+
+  app.get('/html', (req, res) {
+    res.headers.contentType = ContentType.html;
+    return '<html><body><h1>Title!</h1></body></html>';
+  });
+
+  final context = SecurityContext(withTrustedRoots: true);
+  var chain = Platform.script.resolve('ssl_chain.pem').toFilePath();
+  var key = Platform.script.resolve('ssl_key.pem').toFilePath();
+
+  context.useCertificateChain(chain);
+  context.usePrivateKey(key);
+
+  await app.listenSecurity(
+    port: 3000,
+    securityContext: context,
+  );
+}

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -281,7 +281,7 @@ class Alfred {
     return server = _server;
   }
 
-  Future<HttpServer> listenSecurity({
+  Future<HttpServer> listenSecure({
     required SecurityContext securityContext,
     int port = 3000,
     dynamic bindIp = '0.0.0.0',

--- a/lib/src/alfred.dart
+++ b/lib/src/alfred.dart
@@ -255,13 +255,47 @@ class Alfred {
 
   /// Call this function to fire off the server.
   ///
-  Future<HttpServer> listen(
-      [int port = 3000,
-      dynamic bindIp = '0.0.0.0',
-      bool shared = true,
-      int backlog = 0]) async {
-    final _server =
-        await HttpServer.bind(bindIp, port, shared: shared, backlog: backlog);
+  ///
+  ///
+  Future<HttpServer> listen([
+    int port = 3000,
+    dynamic bindIp = '0.0.0.0',
+    bool shared = true,
+    int backlog = 0,
+  ]) async {
+    final _server = await HttpServer.bind(
+      bindIp,
+      port,
+      backlog: backlog,
+      shared: shared,
+    );
+
+    _server.idleTimeout = Duration(seconds: 1);
+
+    _server.listen((HttpRequest request) {
+      requestQueue.add(() => _incomingRequest(request));
+    });
+
+    logWriter(
+        () => 'HTTP Server listening on port ${_server.port}', LogType.info);
+    return server = _server;
+  }
+
+  Future<HttpServer> listenSecurity({
+    required SecurityContext securityContext,
+    int port = 3000,
+    dynamic bindIp = '0.0.0.0',
+    bool shared = true,
+    int backlog = 0,
+  }) async {
+    final _server = await HttpServer.bindSecure(
+      bindIp,
+      port,
+      securityContext,
+      backlog: backlog,
+      shared: shared,
+    );
+
     _server.idleTimeout = Duration(seconds: 1);
 
     _server.listen((HttpRequest request) {

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -118,7 +118,7 @@ void main() {
         port: port,
         securityContext: context,
       );
-      fail('was not for this server to have started');
+      fail('Was not for this server to have started.');
     } catch (e) {
       expect(
         e.toString(),
@@ -140,7 +140,7 @@ void main() {
         port: port,
         securityContext: context,
       );
-      fail('was not for this server to have started');
+      fail('Was not for this server to have started.');
     } catch (e) {
       expect(
         e.toString(),

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -105,6 +105,50 @@ void main() {
     expect(response.statusCode, 404);
   });
 
+  test('Invalid ssl chain & key - file', () async {
+    await app.close();
+    app = Alfred();
+
+    try {
+      var context = SecurityContext();
+      context.useCertificateChain('');
+      context.usePrivateKey('');
+
+      await app.listenSecurity(
+        port: port,
+        securityContext: context,
+      );
+      fail('was not for this server to have started');
+    } catch (e) {
+      expect(
+        e.toString(),
+        contains('FileSystemException: Cannot open file, path'),
+      );
+    }
+  });
+
+  test('Invalid ssl chain & key - bytes', () async {
+    await app.close();
+    app = Alfred();
+
+    try {
+      var context = SecurityContext();
+      context.useCertificateChainBytes([]);
+      context.usePrivateKeyBytes([]);
+
+      await app.listenSecurity(
+        port: port,
+        securityContext: context,
+      );
+      fail('was not for this server to have started');
+    } catch (e) {
+      expect(
+        e.toString(),
+        contains('TlsException: Failure in useCertificateChainBytes'),
+      );
+    }
+  });
+
   test('not found with middleware', () async {
     app.all('*', cors());
     app.get('resource2', (req, res) {});

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -114,7 +114,7 @@ void main() {
       context.useCertificateChain('');
       context.usePrivateKey('');
 
-      await app.listenSecurity(
+      await app.listenSecure(
         port: port,
         securityContext: context,
       );
@@ -136,7 +136,7 @@ void main() {
       context.useCertificateChainBytes([]);
       context.usePrivateKeyBytes([]);
 
-      await app.listenSecurity(
+      await app.listenSecure(
         port: port,
         securityContext: context,
       );


### PR DESCRIPTION
**Changes**
- added new listen with mandatory `securityContext` field
- added 2 tests to validate errors when trying to pass an invalid context.
- added a new example for using SSL