### PR TITLE
fix: headers not being sent with response

### DIFF
--- a/lib/src/middleware/cors.dart
+++ b/lib/src/middleware/cors.dart
@@ -13,6 +13,7 @@ FutureOr Function(HttpRequest, HttpResponse) cors(
     res.headers.set('Access-Control-Allow-Origin', origin);
     res.headers.set('Access-Control-Allow-Methods', methods);
     res.headers.set('Access-Control-Allow-Headers', headers);
+    res.headers.set('Access-Control-Expose-Headers', headers);
     res.headers.set('Access-Control-Max-Age', age);
     if (req.method == 'OPTIONS') {
       res.close();


### PR DESCRIPTION
Fixed issue using flutter web where response headers were being blocked when sent from alfred.