### PR TITLE
Enchant: Class-Based Middlewares and Endpoint callback

### DIFF
--- a/example/example_middleware_authentication_wildcard_with_mixin.dart
+++ b/example/example_middleware_authentication_wildcard_with_mixin.dart
@@ -1,0 +1,25 @@
+import 'dart:async';
+
+import 'package:alfred/alfred.dart';
+
+class _AuthenticationMiddleware with CallableRequestMixin{
+  @override
+  FutureOr call(HttpRequest req, HttpResponse res) async{
+    res.statusCode = 401;
+    await res.close();
+  }
+}
+
+void main() async {
+  final app = Alfred();
+
+  app.all('/resource*', _AuthenticationMiddleware());
+
+  app.get('/resource', (req, res) {}); //Will not be hit
+  app.post('/resource', (req, res) {}); //Will not be hit
+  app.post('/resource/1', (req, res) {}); //Will not be hit
+
+  await app.listen();
+}
+
+

--- a/example/example_middleware_with_mixin.dart
+++ b/example/example_middleware_with_mixin.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+import 'package:alfred/alfred.dart';
+
+class _ExampleMiddleware with CallableRequestMixin{
+  @override
+  FutureOr call(HttpRequest req, HttpResponse res) {
+    if (req.headers.value('Authorization') != 'apikey') {
+      throw AlfredException(401, {'message': 'authentication failed'});
+    }
+  }
+}
+void main() async {
+  final app = Alfred();
+  app.all('/example/:id/:name', (req, res) {}, middleware: [_ExampleMiddleware()]);
+
+  await app.listen(); //Listening on port 3000
+}

--- a/lib/alfred.dart
+++ b/lib/alfred.dart
@@ -13,3 +13,4 @@ export 'src/middleware/cors.dart';
 export 'src/plugins/store_plugin.dart';
 export 'src/type_handlers/type_handler.dart';
 export 'src/route_param_types/http_route_param_type.dart';
+export 'src/mixins/callable_request_mixin.dart';

--- a/lib/src/mixins/callable_request_mixin.dart
+++ b/lib/src/mixins/callable_request_mixin.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+import 'package:alfred/alfred.dart';
+
+/// A Mixin to Resquest Callback
+/// 
+/// Use this mixin to create a callable class 
+/// that can be used like a 
+/// callback enpoint or middlewares
+
+mixin CallableRequestMixin {
+
+   FutureOr<dynamic> call(HttpRequest req, HttpResponse res);
+
+}
+

--- a/test/alfred_test.dart
+++ b/test/alfred_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -29,6 +30,12 @@ void main() {
     final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.headers['content-type'], 'application/json; charset=utf-8');
     expect(response.body, '{"test":true}');
+  });
+  test('With Mixin: it should return json', () async {
+    app.get('/test', _CallableRequest() );
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.headers['content-type'], 'application/json; charset=utf-8');
+    expect(response.body, '{"ok":true,"msg":"callable class"}');
   });
 
   test('it should return an image', () async {
@@ -258,6 +265,12 @@ void main() {
         return 'hit middleware';
       }
     ]);
+    final response = await http.get(Uri.parse('http://localhost:$port/test'));
+    expect(response.body, 'hit middleware');
+  });
+
+  test('With Mixin: it executes middleware, but handles it and stops executing', () async {
+    app.get('/test', (req, res) => 'test route', middleware: [_TestHitMiddleware()]);
     final response = await http.get(Uri.parse('http://localhost:$port/test'));
     expect(response.body, 'hit middleware');
   });
@@ -659,5 +672,19 @@ class RefNumberTypeParameter implements HttpRouteParamType {
   @override
   String parse(String value) {
     return value.toUpperCase();
+  }
+}
+
+class _CallableRequest with CallableRequestMixin{
+  @override
+  FutureOr call(HttpRequest req, HttpResponse res) {
+    return res.json({'ok':true,'msg':'callable class'});
+  }
+}
+
+class _TestHitMiddleware with CallableRequestMixin{
+  @override
+  FutureOr call(HttpRequest req, HttpResponse res) {
+    return 'hit middleware';
   }
 }


### PR DESCRIPTION
Thanks for this amazing idea! 
Inspired by this Issue : https://github.com/rknell/alfred/issues/88

With this Mixin we can create class-based middlewares
```dart
class _ExampleMiddleware with CallableRequestMixin{
  @override
  FutureOr call(HttpRequest req, HttpResponse res) {
    if (req.headers.value('Authorization') != 'apikey') {
      throw AlfredException(401, {'message': 'authentication failed'});
    }
  }
}

void main() async {
  final app = Alfred();
  app.all('/example/:id/:name', (req, res) {}, middleware: [_ExampleMiddleware()]);

  await app.listen(); //Listening on port 3000
}
```
and End-Point callback too !
```dart
class _RequestController with CallableRequestMixin {
  @override
  FutureOr call(HttpRequest req, HttpResponse res) => "I'm a Class :)";
}

void main() async {
  final app = Alfred();

  app.get('/text', _RequestController());

  await app.listen(6565); //Listening on port 6565
}
```

