### PR TITLE
fix tryParse usage

### DIFF
--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -24,7 +24,7 @@ class HttpRoute {
       {this.middleware = const []})
       : usesWildcardMatcher = route.contains('*') {
     // Split route path into segments
-    final segments = Uri.tryParse(route.normalizePath)?.pathSegments ??
+    final segments = Uri.tryParse('/${route.normalizePath}')?.pathSegments ??
         [route.normalizePath];
 
     var pattern = '^';


### PR DESCRIPTION
`Uri.tryParse` aways expect a path starting with `/` and the `normalizePath` removes, so the `.pathSegments` is aways null, thus, no route with more than one variable is working.