### PR TITLE
Set content type for serializable types

### DIFF
--- a/lib/src/type_handlers/serializable_type_handler.dart
+++ b/lib/src/type_handlers/serializable_type_handler.dart
@@ -7,6 +7,7 @@ TypeHandler<dynamic> get serializableTypeHandler =>
     TypeHandler<dynamic>((HttpRequest req, HttpResponse res, dynamic value) {
       try {
         if (value.toJson != null) {
+          res.headers.contentType = ContentType.json;
           res.write(jsonEncode(value.toJson()));
           return res.close();
         }
@@ -18,6 +19,7 @@ TypeHandler<dynamic> get serializableTypeHandler =>
 
       try {
         if (value.toJSON != null) {
+          res.headers.contentType = ContentType.json;
           res.write(jsonEncode(value.toJSON()));
           return res.close();
         }

--- a/test/type_handlers/serializable_type_handler_test.dart
+++ b/test/type_handlers/serializable_type_handler_test.dart
@@ -38,6 +38,39 @@ void main() {
     expect(response3.statusCode, 500);
     expect(response3.body.contains('_NonSerializableObj'), true);
   });
+
+  test('it sets the mime type correctly for serializable types', () async {
+    app.get('/testSerializable1', (req, res) async {
+      return _SerializableObjType1();
+    });
+    app.get('/testSerializable2', (req, res) async {
+      return _SerializableObjType1();
+    });
+    app.get('/testNoSerialize', (req, res) async {
+      return _NonSerializableObj();
+    });
+
+    final response1 =
+        await http.get(Uri.parse('http://localhost:$port/testSerializable1'));
+    expect(
+      response1.headers['content-type'],
+      'application/json; charset=utf-8',
+    );
+
+    final response2 =
+        await http.get(Uri.parse('http://localhost:$port/testSerializable2'));
+    expect(
+      response2.headers['content-type'],
+      'application/json; charset=utf-8',
+    );
+
+    final response3 =
+        await http.get(Uri.parse('http://localhost:$port/testNoSerialize'));
+    expect(
+      response3.headers['content-type'],
+      isNot('application/json; charset=utf-8'),
+    );
+  });
 }
 
 class _SerializableObjType1 {


### PR DESCRIPTION
Currently `serializableTypeHandler` doesn't set content type on the response headers, causing client parsers to fail to deserialize responses as maps/json objects. The PR makes the handler set `application/json` mime type for valid serializable types.