### PR TITLE
Basic Open API implementation

### DIFF
--- a/example/example_open_api.dart
+++ b/example/example_open_api.dart
@@ -1,0 +1,42 @@
+import 'package:alfred/alfred.dart';
+import 'package:alfred/src/alfred_openapi.dart';
+
+void main() async {
+  final app = Alfred();
+
+  app.get(
+    '/path/:param1',
+    (req, res) {
+      res.json({'key': 'value'});
+    },
+    middleware: [],
+    openAPIDoc: OpenAPIDoc(
+      title: 'Title of the endpoint',
+      description: 'Description for the endpoint',
+      responses: [
+        OpenAPIResponse(
+          statusCode: 200,
+          description: 'Success',
+          schema: [
+            OpenAPIResponseContent(
+              key: 'key',
+              type: OpenAPIType.string,
+              example: 'value ABC',
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+
+  app.get('/openapi', (req, res) {
+    res.setContentTypeFromExtension('yaml');
+    return app.getRoutesSpecifications(
+      title: "Test API",
+      description: "Test API Description",
+      version: "1.2.3",
+    );
+  });
+
+  await app.listen();
+}

--- a/example/example_open_api.dart
+++ b/example/example_open_api.dart
@@ -1,5 +1,4 @@
 import 'package:alfred/alfred.dart';
-import 'package:alfred/src/alfred_openapi.dart';
 
 void main() async {
   final app = Alfred();
@@ -26,6 +25,28 @@ void main() async {
           ],
         ),
       ],
+    ),
+  );
+
+  app.patch(
+    '/path/:param2',
+    (req, res) {
+      res.json({'key': 'value'});
+    },
+    middleware: [],
+    openAPIDoc: OpenAPIDoc(
+      title: 'Title of the endpoint',
+      description: 'Description for the endpoint',
+      responses: [],
+      request: OpenAPIRequest(
+        schema: [
+          OpenAPIResponseContent(
+            key: 'key',
+            type: OpenAPIType.string,
+            example: 'value ABC',
+          ),
+        ],
+      ),
     ),
   );
 

--- a/lib/alfred.dart
+++ b/lib/alfred.dart
@@ -2,6 +2,7 @@ export 'dart:io' show HttpRequest, HttpResponse;
 
 export 'src/alfred.dart';
 export 'src/alfred_exception.dart';
+export 'src/alfred_openapi.dart';
 export 'src/router.dart';
 export 'src/body_parser/http_body.dart';
 export 'src/extensions/file_helpers.dart';

--- a/lib/src/alfred_openapi.dart
+++ b/lib/src/alfred_openapi.dart
@@ -1,0 +1,158 @@
+import 'package:alfred/alfred.dart';
+import 'package:yaml_writer/yaml_writer.dart';
+
+enum OpenAPIType {
+  string,
+  number,
+  integer,
+  boolean,
+  array,
+  object;
+
+  String toJson() {
+    return toString().split('.').last;
+  }
+}
+
+enum OpenAPIContentType {
+  object,
+  array;
+
+  String toJson() {
+    return toString().split('.').last;
+  }
+}
+
+/// Extension to generate OpenAPI specifications for the routes in the Alfred app
+extension AlfredOpenAPI on Alfred {
+  /// Returns the OpenAPI specifications for the routes in the Alfred app
+  /// - [title] is the title of the API
+  /// - [description] is the description of the API
+  /// - [version] is the version of the API
+  String getRoutesSpecifications(
+      {String? title, String? description, String? version}) {
+    var specsYaml = YamlWriter();
+    Map<String, dynamic> specs = {
+      'openapi': '3.0.0',
+      'info': {
+        'title': title ?? 'API',
+        'description': description ?? 'API Description',
+        'version': version ?? '1.0.0'
+      },
+      'paths': [],
+    };
+    for (var route in routes) {
+      String methodString = route.method.name;
+      var routeParameters = <Map<String, dynamic>>[];
+
+      for (var parameter in route.params) {
+        routeParameters.add({
+          'name': parameter.name,
+          'in': 'query',
+          'required': true,
+          'schema': {'type': parameter.type?.name ?? 'string'}
+        });
+      }
+
+      (specs['paths'] as List).add({
+        route.route: {
+          methodString: {
+            'summary': route.openAPIDoc?.title ?? 'Summary',
+            if (route.openAPIDoc?.description != null)
+              'description': route.openAPIDoc!.description,
+            'parameters': routeParameters,
+            'responses': {
+              if (route.openAPIDoc?.responses != null)
+                for (var response in route.openAPIDoc!.responses)
+                  ...response.toJson(),
+              if (route.openAPIDoc?.responses == null ||
+                  route.openAPIDoc!.responses.isEmpty)
+                '200': {
+                  'description': 'Success',
+                }
+            }
+          }
+        }
+      });
+    }
+
+    return specsYaml.write(specs).replaceAll('- /', '/');
+  }
+}
+
+/// Class to define the OpenAPI documentation
+class OpenAPIDoc {
+  final String title;
+  final String? description;
+  final List<OpenAPIResponse> responses;
+
+  OpenAPIDoc({
+    required this.title,
+    this.description,
+    required this.responses,
+  });
+}
+
+/// Class to define the OpenAPI response
+class OpenAPIResponse {
+  final int statusCode;
+  final String? description;
+  final String contentType;
+  final OpenAPIContentType content;
+  final List<OpenAPIResponseContent> schema;
+
+  OpenAPIResponse({
+    required this.statusCode,
+    this.description,
+    this.contentType = 'application/json',
+    this.content = OpenAPIContentType.object,
+    required this.schema,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      '$statusCode': {
+        'description': description,
+        'content': {
+          contentType: {
+            'schema': {
+              'type': content.toJson(),
+              if (content == OpenAPIContentType.object)
+                'properties': {
+                  for (var item in schema) ...item.toJson(),
+                },
+              if (content == OpenAPIContentType.array)
+                'items': {
+                  'type': schema.first.type.toJson(),
+                  if (schema.first.example != null)
+                    'example': schema.first.example,
+                },
+            },
+          },
+        },
+      }
+    };
+  }
+}
+
+/// Class to define the OpenAPI response content
+class OpenAPIResponseContent {
+  final String key;
+  final OpenAPIType type;
+  final dynamic example;
+
+  OpenAPIResponseContent({
+    required this.key,
+    required this.type,
+    this.example,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      key: {
+        'type': type.toJson(),
+        if (example != null) 'example': example,
+      }
+    };
+  }
+}

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:alfred/src/alfred_openapi.dart';
-
 import '../alfred.dart';
 
 class HttpRoute {
@@ -10,7 +8,7 @@ class HttpRoute {
 
   /// The OpenAPI documentation for this route
   final OpenAPIDoc? openAPIDoc;
-  
+
   final FutureOr Function(HttpRequest req, HttpResponse res) callback;
   final List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware;
 

--- a/lib/src/http_route.dart
+++ b/lib/src/http_route.dart
@@ -1,10 +1,16 @@
 import 'dart:async';
 
+import 'package:alfred/src/alfred_openapi.dart';
+
 import '../alfred.dart';
 
 class HttpRoute {
   final Method method;
   final String route;
+
+  /// The OpenAPI documentation for this route
+  final OpenAPIDoc? openAPIDoc;
+  
   final FutureOr Function(HttpRequest req, HttpResponse res) callback;
   final List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware;
 
@@ -20,9 +26,13 @@ class HttpRoute {
 
   Iterable<HttpRouteParam> get params => _params.values;
 
-  HttpRoute(this.route, this.callback, this.method,
-      {this.middleware = const []})
-      : usesWildcardMatcher = route.contains('*') {
+  HttpRoute(
+    this.route,
+    this.callback,
+    this.method, {
+    this.middleware = const [],
+    this.openAPIDoc,
+  }) : usesWildcardMatcher = route.contains('*') {
     // Split route path into segments
 
     /// Because in dart 2.18 uri parsing is more permissive, using a \ in regex

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -5,6 +5,7 @@ import 'package:alfred/src/route_group.dart';
 import 'package:meta/meta.dart';
 
 import 'alfred.dart';
+import 'alfred_openapi.dart';
 import 'http_route.dart';
 
 mixin Router {
@@ -20,8 +21,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.get, path, callback, middleware);
+      createRoute(Method.get, path, callback, middleware, openAPIDoc);
 
   /// Create a head route
   ///
@@ -30,8 +32,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.head, path, callback, middleware);
+      createRoute(Method.head, path, callback, middleware, openAPIDoc);
 
   /// Create a post route
   ///
@@ -40,8 +43,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.post, path, callback, middleware);
+      createRoute(Method.post, path, callback, middleware, openAPIDoc);
 
   /// Create a put route
   HttpRoute put(
@@ -49,8 +53,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.put, path, callback, middleware);
+      createRoute(Method.put, path, callback, middleware, openAPIDoc);
 
   /// Create a delete route
   ///
@@ -59,8 +64,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.delete, path, callback, middleware);
+      createRoute(Method.delete, path, callback, middleware, openAPIDoc);
 
   /// Create a patch route
   ///
@@ -69,8 +75,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.patch, path, callback, middleware);
+      createRoute(Method.patch, path, callback, middleware, openAPIDoc);
 
   /// Create an options route
   ///
@@ -79,8 +86,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.options, path, callback, middleware);
+      createRoute(Method.options, path, callback, middleware, openAPIDoc);
 
   /// Create a route that listens on all methods
   ///
@@ -89,8 +97,9 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, {
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   }) =>
-      createRoute(Method.all, path, callback, middleware);
+      createRoute(Method.all, path, callback, middleware, openAPIDoc);
 
   HttpRoute createRoute(
     Method method,
@@ -98,10 +107,15 @@ mixin Router {
     FutureOr Function(HttpRequest req, HttpResponse res) callback, [
     List<FutureOr Function(HttpRequest req, HttpResponse res)> middleware =
         const [],
+    OpenAPIDoc? openAPIDoc,
   ]) {
     final route = HttpRoute(
-        '${pathPrefix == '' ? '' : '$pathPrefix/'}$path', callback, method,
-        middleware: middleware);
+      '${pathPrefix == '' ? '' : '$pathPrefix/'}$path',
+      callback,
+      method,
+      middleware: middleware,
+      openAPIDoc: openAPIDoc,
+    );
     app.addRoute(route);
     return route;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   queue: ^3.1.0
   path: ^1.8.2
   meta: ^1.3.0
+  yaml: ^3.1.3
+  yaml_writer: ^2.0.1
 
 dev_dependencies:
   test: ^1.21.4


### PR DESCRIPTION
@rknell Created a PR instead of an issue to demonstrate the proof of concept.
The idea would be to make Alfred compatible with OpenAPI to use with softwares like Insomnia and Postman aswell as providing clean documentation for external developers to one's project.

Before going too far and doing a complete (and clean!) implementation of this, I wanted your take on this.

The way I see this, it would add an optionnal route parameter called "openAPIDoc" in which you could specify more details about the route. By default, it would at least render the path and path parameter.

Looking at my example, a simple route could be instantiated to open the OpenAPI document to the public.

As I mentionned, it's only a PoC before doing an actual implementation of this. 
Is this something you would want in Alfred?

Thanks!

As a side note, below is a screenshot of the outputed file (left) and used with swagger (right)
![image](https://github.com/user-attachments/assets/db891198-2e9b-4d40-9bb1-0a745ed76ced)
